### PR TITLE
fix: android termux build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,7 +2023,9 @@ dependencies = [
  "cesu8",
  "cfg-if 1.0.0",
  "combine",
+ "java-locator",
  "jni-sys",
+ "libloading",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2131,6 +2142,16 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
 
 [[package]]
 name = "libredox"
@@ -3625,6 +3646,7 @@ dependencies = [
  "dirs",
  "hex",
  "indicatif",
+ "jni",
  "sha2 0.10.8",
  "stigmerge_fileindex",
  "stigmerge_peer",
@@ -3632,6 +3654,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "veilid-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ Or add the default package to a legacy `home.nix` with something like:
 
     (builtins.getFlake "github:cmars/stigmerge").packages.x86_64-linux.default
 
+## Android (termux binary)
+
+Stigmerge can be compiled from source and run on the command-line with [Termux](https://termux.dev) on Android.
+
+You'll need to install Rust and Cargo to build it, and the following runtime dependencies:
+
+```bash
+pkg install which
+pkg install openjdk-21
+```
+
+Other JDKs might work as well, YMMV. Comments in
+[stigmerge/src/bin/stigmerge.rs](./stigmerge/src/bin/stigmerge.rs) explain why
+this is currently necessary.
+
 # Plans
 
 What's on the roadmap for a 1.0 release.

--- a/stigmerge-peer/src/veilid_config.rs
+++ b/stigmerge-peer/src/veilid_config.rs
@@ -23,7 +23,9 @@ pub fn callback(state_dir: String, ns: Option<String>, key: String) -> ConfigCal
         "block_store.directory" => Ok(Box::new(get_block_store_path(&state_dir))),
         "block_store.delete" => Ok(Box::new(false)),
         "protected_store.allow_insecure_fallback" => Ok(Box::new(true)),
-        "protected_store.always_use_insecure_storage" => Ok(Box::new(false)),
+        "protected_store.always_use_insecure_storage" => {
+            Ok(Box::new(always_use_insecure_storage()))
+        }
         "protected_store.directory" => Ok(Box::new(get_protected_store_path(&state_dir))),
         "protected_store.delete" => Ok(Box::new(false)),
         "protected_store.device_encryption_key_password" => Ok(Box::new("".to_owned())),
@@ -118,6 +120,16 @@ pub fn callback(state_dir: String, ns: Option<String>, key: String) -> ConfigCal
             Err(VeilidAPIError::internal(err))
         }
     }
+}
+
+#[cfg(not(target_os = "android"))]
+fn always_use_insecure_storage() -> bool {
+    false
+}
+
+#[cfg(target_os = "android")]
+fn always_use_insecure_storage() -> bool {
+    true
 }
 
 fn get_block_store_path(state_dir: &String) -> String {

--- a/stigmerge/Cargo.toml
+++ b/stigmerge/Cargo.toml
@@ -33,9 +33,13 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+veilid-core = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 sha2 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 sha2 = "0.10.8"
+
+[target.'cfg(target_os = "android")'.dependencies]
+jni = { version = "0.21.1", features = ["invocation"] }

--- a/stigmerge/src/bin/stigmerge.rs
+++ b/stigmerge/src/bin/stigmerge.rs
@@ -5,8 +5,69 @@ use clap::Parser;
 
 use stigmerge::{App, Cli};
 
+#[cfg(target_os = "android")]
+use jni::{objects::JObject, InitArgsBuilder, JNIVersion, JavaVM};
+
+/// Initialize native platform-specific stuff.
+///
+/// veilid-core has android-specific code that assumes if you're running on
+/// android, you're an app which has called
+/// veilid_core::veilid_core_setup_android. And if you haven't, veilid-core
+/// configuration will error out.
+///
+/// This assumption is not valid for the case of a command-line binary like this
+/// one, when running on android though. Which is kind of a hacker thing to do
+/// already, but it can be done with adb shell or termux.
+///
+/// To work around this, we can set up android with a new JVM instance and pass
+/// null for the AndroidKeyringContext. That new JVM instance requires an
+/// available libjvm -- which might need to be installed separately into the
+/// android execution environment. The null keyring context could result in an
+/// NPE in keyring-manager, so we'll also conditionally compile android to
+/// always use an insecure keyring.
+///
+/// These are both hacks around some assumptions in veilid-core that could be
+/// improved upon by refining the android-specific codepaths there.
+///
+/// Another option would be, a stigmerge Android library. That library could
+/// handle the initialization the same way veilid-flutter does.
+#[cfg(target_os = "android")]
+fn init_native() -> Result<()> {
+    // Build the VM properties
+    let jvm_args = InitArgsBuilder::new()
+        // Pass the JNI API version (default is 8)
+        .version(JNIVersion::V8)
+        // You can additionally pass any JVM options (standard, like a system property,
+        // or VM-specific).
+        // Here we could enable some extra JNI checks useful during development
+        //.option("-Xcheck:jni")
+        .build()?;
+
+    // Create a new VM.
+    let jvm = JavaVM::new(jvm_args)?;
+
+    // Attach the current thread to call into Java — see extra options in
+    // "Attaching Native Threads" section.
+    //
+    // This method returns the guard that will detach the current thread when dropped,
+    // also freeing any local references created in it
+    let env = jvm.attach_current_thread()?;
+
+    unsafe {
+        veilid_core::veilid_core_setup_android(env.unsafe_clone(), JObject::null());
+    }
+    Ok(())
+}
+
+/// Placeholder for platform-specific native initialization.
+#[cfg(not(target_os = "android"))]
+fn init_native() -> Result<()> {
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_native()?;
     if let Err(e) = tokio_main().await {
         eprintln!("{} error: Something went wrong", env!("CARGO_PKG_NAME"));
         Err(e)


### PR DESCRIPTION
Workaround for "veilid_core::core_context: error=Internal: Android globals are not set up" error when building and running on Android in termux.

Added details to README on android CLI building and runtime deps.