### PR TITLE
refactor!: indicate block not found with none

### DIFF
--- a/stigmerge-peer/src/node/mod.rs
+++ b/stigmerge-peer/src/node/mod.rs
@@ -49,12 +49,12 @@ pub trait Node: Clone + Send {
         target: Target,
         piece: usize,
         block: usize,
-    ) -> impl Future<Output = Result<Vec<u8>>> + Send;
+    ) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send;
 
     fn reply_block_contents(
         &mut self,
         call_id: OperationId,
-        contents: &[u8],
+        contents: Option<&[u8]>,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn request_advertise_peer(


### PR DESCRIPTION
Use Option<&[u8]> to indicate presence of a block (Some) or lack thereof (None).

Protocol remains the same, but the Node API is updated to make this distinction clear.

This does have the consequence that there's no way to positively acknowledge an empty block with something like Some(&[]), which should be fine.