### PR TITLE
feat: add share key to target updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
  "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -790,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1045,7 +1045,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.9",
  "signature",
@@ -1587,7 +1587,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -1608,7 +1608,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -1862,7 +1862,7 @@ checksum = "bc3be8d8cd36f33a46b1849f31f837c44d9fa87223baee3b4bd96b8f11df81eb"
 dependencies = [
  "bitmaps",
  "imbl-sized-chunks",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "serde",
  "version_check",
@@ -2678,7 +2678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2907,8 +2907,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2918,7 +2928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2931,12 +2951,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3261,7 +3290,7 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "num",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "zbus",
@@ -3643,6 +3672,7 @@ dependencies = [
  "flume",
  "hex",
  "path-absolutize",
+ "rand 0.9.1",
  "sha2 0.10.9",
  "stigmerge_fileindex",
  "tempfile",
@@ -4042,7 +4072,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -4258,7 +4288,7 @@ checksum = "ce2b3c073da0025538ff4cf5bea61a7a7a046c1bf060e2d0981c71800747551d"
 dependencies = [
  "attohttpc",
  "log",
- "rand",
+ "rand 0.8.5",
  "url",
  "xmltree",
 ]
@@ -4299,8 +4329,8 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "postcard",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "range-set-blaze",
  "rtnetlink",
  "send_wrapper 0.6.0",
@@ -4861,7 +4891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]

--- a/stigmerge-peer/Cargo.toml
+++ b/stigmerge-peer/Cargo.toml
@@ -22,6 +22,7 @@ stigmerge_fileindex = { version = "0", path = "../stigmerge-fileindex" }
 flume = { version = "0.11", features = ["async"] }
 hex = "0.4"
 path-absolutize = "3.1"
+rand = "0.9"
 thiserror = "2.0"
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -108,7 +108,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
     // Set up share resolver
     let share_resolver = ShareResolver::new(node.clone());
     let target_rx = share_resolver.subscribe_target();
-    let mut share_resolve_op = Operator::new(
+    let mut share_resolver_op = Operator::new(
         cancel.clone(),
         share_resolver,
         WithVeilidConnection::new(node.clone(), conn_state.clone()),
@@ -125,14 +125,14 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
                 .map_err(|_| Error::msg("Invalid digest length"))?;
 
             // Resolve the index from the bootstrap peer
-            share_resolve_op
+            share_resolver_op
                 .send(share_resolver::Request::Index {
                     key: share_key.clone(),
                     want_index_digest: Some(want_index_digest),
                     root: root.clone(),
                 })
                 .await?;
-            let index = match share_resolve_op.recv().await {
+            let index = match share_resolver_op.recv().await {
                 Some(share_resolver::Response::Index { index, .. }) => index,
                 Some(share_resolver::Response::BadIndex { .. }) => anyhow::bail!("Bad index"),
                 Some(share_resolver::Response::NotAvailable { err_msg, .. }) => {
@@ -190,6 +190,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
             Arc::new(RwLock::new(index.clone())),
             index.root().to_path_buf(),
             target_rx,
+            share_resolver_op.client_tx(),
         ),
         WithVeilidConnection::new(node.clone(), conn_state.clone()),
         args.fetchers,

--- a/stigmerge-peer/src/fetcher.rs
+++ b/stigmerge-peer/src/fetcher.rs
@@ -150,6 +150,7 @@ impl Fetcher {
                     return Err(Error::msg("plan cancelled"))
                 }
                 res = self.clients.block_fetcher.send(block_fetcher::Request::Fetch {
+                    share_key: None,
                     block: FileBlockFetch {
                         file_index: want_block.file_index,
                         piece_index: want_block.piece_index,
@@ -232,6 +233,7 @@ impl Fetcher {
                         Some(block_fetcher::Response::FetchFailed { block, error_msg }) => {
                             warn!("failed to fetch block: {}", error_msg);
                             self.clients.block_fetcher.send(block_fetcher::Request::Fetch {
+                                share_key: None,
                                 block: block.clone(),
                                 flush: false
                             }).await?;
@@ -280,6 +282,7 @@ impl Fetcher {
                             for block_index in 0..piece_blocks  {
                                 self.clients.block_fetcher.send(
                                     block_fetcher::Request::Fetch {
+                                        share_key: None,
                                         block: FileBlockFetch {
                                            file_index,
                                            piece_index,

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use tokio::{select, sync::broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, Level};
+use tracing::{debug, info, Level};
 use veilid_core::{ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
@@ -136,6 +136,7 @@ impl<P: Node> Actor for HaveResolver<P> {
     async fn handle(&mut self, req: &Request) -> Result<Response> {
         Ok(match req {
             Request::Resolve { key } => {
+                debug!("Request::Resolve {key}");
                 let have_map = self.node.resolve_have_map(key).await?;
                 Response::Resolve {
                     key: key.to_owned(),
@@ -143,6 +144,7 @@ impl<P: Node> Actor for HaveResolver<P> {
                 }
             }
             Request::Watch { key } => {
+                debug!("Request::Watch {key}");
                 let (_, header) = self.node.resolve_route(key, None).await?;
                 if let Some(have_map_ref) = header.have_map() {
                     self.have_to_share_map
@@ -162,6 +164,7 @@ impl<P: Node> Actor for HaveResolver<P> {
                 }
             }
             Request::CancelWatch { key } => {
+                debug!("Request::CancelWatch {key}");
                 let (_, header) = self.node.resolve_route(key, None).await?;
                 if let Some(have_map_ref) = header.have_map() {
                     self.have_to_share_map.remove(have_map_ref.key());

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -1,7 +1,7 @@
 use stigmerge_fileindex::Index;
 use tokio::{select, sync::broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, Level};
+use tracing::{debug, info, Level};
 use veilid_core::{Target, VeilidUpdate};
 
 use crate::{actor::Actor, node::TypedKey, proto::Header, Node, Result};
@@ -135,6 +135,10 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
     async fn handle(&mut self, req: &Self::Request) -> Result<Self::Response> {
         match req {
             Request::Announce => {
+                debug!(
+                    "Request::Announce {:?}",
+                    self.share.as_ref().map(|s| s.key.to_string())
+                );
                 return self.reannounce().await;
             }
         }

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, path::PathBuf};
 use stigmerge_fileindex::Index;
 use tokio::{select, sync::broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace, warn, Level};
+use tracing::{debug, info, trace, warn, Level};
 use veilid_core::{Target, ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
@@ -215,6 +215,7 @@ impl<P: Node> Actor for ShareResolver<P> {
                 want_index_digest,
                 root,
             } => {
+                debug!("Request::Index {key}");
                 let (target, header, mut index) =
                     self.node.resolve_route_index(key, root.as_path()).await?;
                 let peer_index_digest = index.digest()?;
@@ -242,8 +243,9 @@ impl<P: Node> Actor for ShareResolver<P> {
                 ref key,
                 prior_target,
             } => {
+                debug!("Request::Header {key}");
                 let (target, header) = self.node.resolve_route(key, *prior_target).await?;
-                let _ = self.target_tx.send((key.clone(), target.to_owned()));
+                let _ = self.target_tx.try_send((key.clone(), target.to_owned()));
                 Response::Header {
                     key: key.clone(),
                     header,


### PR DESCRIPTION
A share_resolver can track multiple share keys, so it should indicate which share key the target route is for.