### PR TITLE
feat: integrate peer announcer, write state files

### DIFF
--- a/stigmerge-peer/examples/peer_announce.rs
+++ b/stigmerge-peer/examples/peer_announce.rs
@@ -86,17 +86,19 @@ async fn main() -> std::result::Result<(), Error> {
     };
     info!("announced share: key={share_key}, target={target:?}");
 
-    // Create peer announcer for our share
-    let mut peer_announcer_op = Operator::new(
+    // Create peer resolver to watch other shares
+    let peer_resolver = peer_resolver::PeerResolver::new(node.clone());
+    let discovered_peer_rx = peer_resolver.subscribe_discovered_peers();
+    let mut peer_resolver_op = Operator::new(
         cancel.clone(),
-        PeerAnnouncer::new(node.clone(), &header.payload_digest()),
+        peer_resolver,
         WithVeilidConnection::new(node.clone(), conn_state.clone()),
     );
 
-    // Create peer resolver to watch other shares
-    let mut peer_resolver_op = Operator::new(
+    // Create peer announcer for our share
+    let mut peer_announcer_op = Operator::new(
         cancel.clone(),
-        peer_resolver::PeerResolver::new(node.clone()),
+        PeerAnnouncer::new(node.clone(), &header.payload_digest(), discovered_peer_rx),
         WithVeilidConnection::new(node.clone(), conn_state.clone()),
     );
 

--- a/stigmerge-peer/src/fetcher.rs
+++ b/stigmerge-peer/src/fetcher.rs
@@ -502,13 +502,16 @@ impl<N: Node> Fetcher<N> {
                     if let None = self.peer_tracker.update(key, target.to_owned()).await {
                         // Never seen this peer before, advertise ourselves to it
                         self.node.request_advertise_peer(&target, &self.share.key).await?;
+                        debug!("advertised our share {} to target {:?}", self.share.key, target);
                     }
                 }
 
                 // Resolve newly discovered peers
+                // TODO: this needs to be in the seeder, if we're done fetching we won't execute this
                 res = self.clients.discovered_peers_rx.recv_async() => {
                     let (key, peer_info) = res?;
                     if !self.peer_tracker.contains(peer_info.key()) {
+                        debug!("discovered peer {} at {key}", peer_info.key());
                         self.clients.share_resolver.call(share_resolver::Request::Index{
                             response_tx: ResponseChannel::default(),
                             key,

--- a/stigmerge/src/cli.rs
+++ b/stigmerge/src/cli.rs
@@ -3,7 +3,6 @@ use std::{io::IsTerminal, path::PathBuf};
 use anyhow::{Error, Result};
 use clap::{arg, Parser, Subcommand};
 use sha2::{Digest, Sha256};
-use tracing::debug;
 
 #[derive(Parser, Debug)]
 #[command(name = "stigmerge")]
@@ -69,7 +68,6 @@ impl Cli {
             .into_os_string()
             .into_string()
             .map_err(|os| Error::msg(format!("{:?}", os)))?;
-        debug!(state_dir);
         Ok(state_dir)
     }
 


### PR DESCRIPTION
Integrate the peer announcer, so that discovered peers are announced to others.

Write files containing the share key and index digest to the state_dir in the main app.  This is useful for orchestrating stigmerge with containers or testing with shadow.

WIP: peer announcer isn't set up quite right yet...