### PR TITLE
chore: remove tracing annotations, add error context instead

### DIFF
--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -111,7 +111,6 @@ pub struct Operator<Req> {
 }
 
 impl<Req: Respondable + Send + Sync + 'static> Operator<Req> {
-    #[tracing::instrument(skip_all)]
     pub fn new<A: Actor<Request = Req> + Clone + Send + 'static, R: Runner<A> + Send + 'static>(
         cancel: CancellationToken,
         actor: A,
@@ -129,7 +128,6 @@ impl<Req: Respondable + Send + Sync + 'static> Operator<Req> {
         }
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn new_clone_pool<
         A: Actor<Request = Req> + Clone + Send + 'static,
         R: Runner<A> + Clone + Send + 'static,
@@ -181,7 +179,6 @@ impl<Req: Respondable + Send + Sync + 'static> Operator<Req> {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all)]
     pub async fn cancel(&self) {
         self.cancel.cancel();
     }

--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -33,7 +33,6 @@ pub use node::{Node, Veilid};
 #[cfg(test)]
 pub mod tests;
 
-#[tracing::instrument(skip_all, fields(state_dir, ns), err)]
 pub async fn new_routing_context(
     state_dir: &str,
     ns: Option<String>,

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -50,7 +50,6 @@ impl App {
         })
     }
 
-    #[tracing::instrument(skip_all)]
     pub async fn run(&mut self) -> Result<()> {
         self.multi_progress
             .println(format!("🐝 stigmerge {}", env!("CARGO_PKG_VERSION")))?;
@@ -79,7 +78,6 @@ impl App {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, err)]
     async fn run_with_node<T: Node + Sync + Send + 'static>(&self, node: T) -> Result<()> {
         let mut tasks = JoinSet::new();
 

--- a/stigmerge/src/bin/stigmerge.rs
+++ b/stigmerge/src/bin/stigmerge.rs
@@ -76,7 +76,6 @@ async fn main() -> Result<()> {
     }
 }
 
-#[tracing::instrument(skip_all, err)]
 async fn tokio_main() -> Result<()> {
     let cli = Cli::parse();
     let mut app = App::new(cli)?;


### PR DESCRIPTION
Tracing annotations seem to build up a huge stack of open traces which are not useful for logging. Removing them and making log messages intentional.

Wrapping errors with intentional context.