### PR TITLE
fix: fetcher implements actor, managed by operator

### DIFF
--- a/stigmerge-peer/examples/fetch_block.rs
+++ b/stigmerge-peer/examples/fetch_block.rs
@@ -6,6 +6,20 @@ use std::sync::Arc;
 
 use backoff::backoff::Backoff;
 use clap::Parser;
+use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
+use stigmerge_peer::block_fetcher::{self, BlockFetcher};
+use stigmerge_peer::new_routing_context;
+use stigmerge_peer::node::Veilid;
+use stigmerge_peer::share_resolver::{self, ShareResolver};
+use stigmerge_peer::types::FileBlockFetch;
+use stigmerge_peer::Error;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio::try_join;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+use veilid_core::TypedKey;
 
 /// Fetch block CLI arguments
 #[derive(Parser, Debug)]
@@ -35,23 +49,6 @@ struct Args {
     #[arg(short, long, help = "Output file path")]
     output: Option<PathBuf>,
 }
-
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
-
-use tokio::sync::Mutex;
-use tokio::try_join;
-use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
-
-use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
-use stigmerge_peer::block_fetcher::{self, BlockFetcher};
-use stigmerge_peer::new_routing_context;
-use stigmerge_peer::node::Veilid;
-use stigmerge_peer::share_resolver::{self, ShareResolver};
-use stigmerge_peer::types::FileBlockFetch;
-use stigmerge_peer::Error;
-use veilid_core::TypedKey;
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {

--- a/stigmerge-peer/examples/peer_announce.rs
+++ b/stigmerge-peer/examples/peer_announce.rs
@@ -5,6 +5,21 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::Parser;
+use stigmerge_fileindex::Indexer;
+use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
+use stigmerge_peer::content_addressable::ContentAddressable;
+use stigmerge_peer::node::Veilid;
+use stigmerge_peer::peer_announcer::{self, PeerAnnouncer};
+use stigmerge_peer::proto::{AdvertisePeerRequest, Decoder};
+use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
+use stigmerge_peer::share_resolver::{self, ShareResolver};
+use stigmerge_peer::{new_routing_context, peer_resolver};
+use stigmerge_peer::{proto, Error, Node};
+use tokio::select;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+use veilid_core::{TypedKey, VeilidUpdate};
 
 /// Peer announce CLI arguments
 #[derive(Parser, Debug)]
@@ -18,23 +33,6 @@ struct Args {
     #[arg(help = "List of peer share keys to announce")]
     peer_keys: Vec<String>,
 }
-
-use stigmerge_peer::content_addressable::ContentAddressable;
-use stigmerge_peer::proto::{AdvertisePeerRequest, Decoder};
-use stigmerge_peer::share_resolver::{self, ShareResolver};
-use tokio::select;
-use tokio::sync::Mutex;
-use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
-use veilid_core::{TypedKey, VeilidUpdate};
-
-use stigmerge_fileindex::Indexer;
-use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
-use stigmerge_peer::node::Veilid;
-use stigmerge_peer::peer_announcer::{self, PeerAnnouncer};
-use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
-use stigmerge_peer::{new_routing_context, peer_resolver};
-use stigmerge_peer::{proto, Error, Node};
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {

--- a/stigmerge-peer/examples/seeder_announcer.rs
+++ b/stigmerge-peer/examples/seeder_announcer.rs
@@ -5,6 +5,21 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
+use stigmerge_fileindex::Indexer;
+use stigmerge_peer::actor::{
+    ConnectionState, OneShot, Operator, ResponseChannel, WithVeilidConnection,
+};
+use stigmerge_peer::content_addressable::ContentAddressable;
+use stigmerge_peer::node::Veilid;
+use stigmerge_peer::seeder::{self, Seeder};
+use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
+use stigmerge_peer::types::{PieceState, ShareInfo};
+use stigmerge_peer::Error;
+use stigmerge_peer::{new_routing_context, piece_verifier, Node};
+use tokio::select;
+use tokio::sync::{Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 /// Seeder announcer CLI arguments
 #[derive(Parser, Debug)]
@@ -14,23 +29,6 @@ struct Args {
     #[arg(help = "Path to the file to seed")]
     file: PathBuf,
 }
-
-use stigmerge_peer::seeder::{self, Seeder};
-use stigmerge_peer::types::{PieceState, ShareInfo};
-use tokio::select;
-use tokio::sync::{Mutex, RwLock};
-use tokio_util::sync::CancellationToken;
-use tracing::info;
-
-use stigmerge_fileindex::Indexer;
-use stigmerge_peer::actor::{
-    ConnectionState, OneShot, Operator, ResponseChannel, WithVeilidConnection,
-};
-use stigmerge_peer::content_addressable::ContentAddressable;
-use stigmerge_peer::node::Veilid;
-use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
-use stigmerge_peer::Error;
-use stigmerge_peer::{new_routing_context, piece_verifier, Node};
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {

--- a/stigmerge-peer/examples/share_announce.rs
+++ b/stigmerge-peer/examples/share_announce.rs
@@ -5,6 +5,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
+use stigmerge_fileindex::Indexer;
+use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
+use stigmerge_peer::new_routing_context;
+use stigmerge_peer::node::Veilid;
+use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
+use stigmerge_peer::Error;
+use tokio::select;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 /// Share announce CLI arguments
 #[derive(Parser, Debug)]
@@ -14,18 +24,6 @@ struct Args {
     #[arg(help = "Path to the file to announce")]
     file: PathBuf,
 }
-
-use tokio::select;
-use tokio::sync::Mutex;
-use tokio_util::sync::CancellationToken;
-use tracing::info;
-
-use stigmerge_fileindex::Indexer;
-use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
-use stigmerge_peer::new_routing_context;
-use stigmerge_peer::node::Veilid;
-use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
-use stigmerge_peer::Error;
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {

--- a/stigmerge-peer/src/block_fetcher.rs
+++ b/stigmerge-peer/src/block_fetcher.rs
@@ -212,6 +212,10 @@ impl<P: Node + Send> Actor for BlockFetcher<P> {
         resp_tx.send(resp).await?;
         Ok(())
     }
+
+    async fn join(self) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl<P: Node> Clone for BlockFetcher<P> {

--- a/stigmerge-peer/src/have_announcer.rs
+++ b/stigmerge-peer/src/have_announcer.rs
@@ -168,6 +168,10 @@ impl<P: Node> Actor for HaveAnnouncer<P> {
             .with_context(|| format!("have_announcer: send response"))?;
         Ok(())
     }
+
+    async fn join(self) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -267,6 +267,10 @@ impl<P: Node> Actor for HaveResolver<P> {
 
         Ok(())
     }
+
+    async fn join(self) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl<P: Node + 'static> Clone for HaveResolver<P> {

--- a/stigmerge-peer/src/peer_announcer.rs
+++ b/stigmerge-peer/src/peer_announcer.rs
@@ -189,7 +189,10 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     Response::Ok
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_announcer: send response")?;
             }
             Request::Redact {
                 key,
@@ -215,7 +218,10 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     Response::Ok
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_announcer: send response")?;
             }
             Request::Reset { mut response_tx } => {
                 let resp = match self
@@ -233,10 +239,17 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_announcer: send response")?;
             }
         }
 
+        Ok(())
+    }
+
+    async fn join(self) -> Result<()> {
         Ok(())
     }
 }

--- a/stigmerge-peer/src/peer_resolver.rs
+++ b/stigmerge-peer/src/peer_resolver.rs
@@ -188,7 +188,10 @@ impl<P: Node> Actor for PeerResolver<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_resolver: send response")?;
             }
             Request::Watch {
                 key,
@@ -226,7 +229,10 @@ impl<P: Node> Actor for PeerResolver<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_resolver: send response")?;
             }
             Request::CancelWatch {
                 key,
@@ -253,10 +259,17 @@ impl<P: Node> Actor for PeerResolver<P> {
                     }
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_resolver: send response")?;
             }
         }
 
+        Ok(())
+    }
+
+    async fn join(self) -> Result<()> {
         Ok(())
     }
 }

--- a/stigmerge-peer/src/piece_verifier.rs
+++ b/stigmerge-peer/src/piece_verifier.rs
@@ -179,7 +179,10 @@ impl Actor for PieceVerifier {
                 .await?
             {
                 self.verified_pieces += 1;
-                self.verified_tx.send_async(req.piece_state()).await.with_context(|| "piece_verifier: notify verified piece")?;
+                self.verified_tx
+                    .send_async(req.piece_state())
+                    .await
+                    .with_context(|| "piece_verifier: notify verified piece")?;
                 Response::ValidPiece {
                     file_index: req.file_index(),
                     piece_index: req.piece_index(),
@@ -201,8 +204,15 @@ impl Actor for PieceVerifier {
         };
 
         let mut response_tx = req.response_tx();
-        response_tx.send(resp).await.with_context(|| "piece_verifier: send response")?;
+        response_tx
+            .send(resp)
+            .await
+            .with_context(|| "piece_verifier: send response")?;
 
+        Ok(())
+    }
+
+    async fn join(self) -> Result<()> {
         Ok(())
     }
 }

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -147,10 +147,17 @@ impl<P: Node> Actor for Seeder<P> {
         match req {
             Request::HaveMap { mut response_tx } => {
                 let resp = Response::HaveMap(self.piece_map.clone());
-                response_tx.send(resp).await.with_context(|| "seeder: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "seeder: send response")?;
                 Ok(())
             }
         }
+    }
+
+    async fn join(self) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -162,8 +162,15 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
             Err(_) => Response::NotAvailable,
         };
 
-        req.response_tx().send(response).await.with_context(|| "share_announcer: send response")?;
+        req.response_tx()
+            .send(response)
+            .await
+            .with_context(|| "share_announcer: send response")?;
 
+        Ok(())
+    }
+
+    async fn join(self) -> Result<()> {
         Ok(())
     }
 }

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -325,7 +325,14 @@ impl<P: Node> Actor for ShareResolver<P> {
         }
         trace!(?resp);
 
-        response_tx.send(resp).await.with_context(|| "share_resolver: send response")?;
+        response_tx
+            .send(resp)
+            .await
+            .with_context(|| "share_resolver: send response")?;
+        Ok(())
+    }
+
+    async fn join(self) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
The fetcher was holding the piece_verifier, to which the seeder subscribes to. This was causing recv errors.

Making the fetcher an actor keeps the process management simpler, less "special cases".