### PR TITLE
fix: deal with unrecoverable errors intentionally

### DIFF
--- a/stigmerge-peer/examples/fetcher_resolver.rs
+++ b/stigmerge-peer/examples/fetcher_resolver.rs
@@ -130,7 +130,7 @@ async fn main() -> std::result::Result<(), Error> {
     let peer_resolver_op = Operator::new(
         cancel.clone(),
         peer_resolver,
-        WithVeilidConnection::new(node.clone(), conn_state.clone()),
+        WithVeilidConnection::new(node.clone(), conn_state),
     );
 
     let clients = Clients {

--- a/stigmerge-peer/examples/share_announce.rs
+++ b/stigmerge-peer/examples/share_announce.rs
@@ -5,6 +5,16 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
+use stigmerge_fileindex::Indexer;
+use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
+use stigmerge_peer::new_routing_context;
+use stigmerge_peer::node::Veilid;
+use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
+use stigmerge_peer::Error;
+use tokio::select;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 /// Share announce CLI arguments
 #[derive(Parser, Debug)]
@@ -14,18 +24,6 @@ struct Args {
     #[arg(help = "Path to the file to announce")]
     file: PathBuf,
 }
-
-use tokio::select;
-use tokio::sync::Mutex;
-use tokio_util::sync::CancellationToken;
-use tracing::info;
-
-use stigmerge_fileindex::Indexer;
-use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
-use stigmerge_peer::new_routing_context;
-use stigmerge_peer::node::Veilid;
-use stigmerge_peer::share_announcer::{self, ShareAnnouncer};
-use stigmerge_peer::Error;
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {

--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -244,7 +244,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
     let seeder_op = Operator::new(
         cancel.clone(),
         seeder,
-        WithVeilidConnection::new(node.clone(), conn_state.clone()),
+        WithVeilidConnection::new(node.clone(), conn_state),
     );
 
     // Create and run fetcher

--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -12,8 +12,8 @@ use tracing::{error, info, warn};
 use veilid_core::{VeilidAPIError, VeilidUpdate};
 
 use crate::{
-    error::{CancelError, Permanent, Transient},
-    Error, Node, Result,
+    error::{CancelError, Result, Transient},
+    is_cancelled, is_unrecoverable, Error, Node,
 };
 
 /// Common interface for RPC services that handle requests and responses over channels.
@@ -184,11 +184,11 @@ impl<Req: Respondable + Send + Sync + 'static> Operator<Req> {
     }
 
     pub async fn join(self) -> Result<()> {
-        for res in self.tasks.join_all().await.into_iter() {
-            if let Err(e) = res {
-                return Err(e);
-            }
-        }
+        self.tasks
+            .join_all()
+            .await
+            .into_iter()
+            .collect::<Result<()>>()?;
         Ok(())
     }
 }
@@ -270,10 +270,34 @@ impl ConnectionState {
     pub fn subscribe(&self) -> watch::Receiver<bool> {
         self.connected.subscribe()
     }
+
+    pub(super) fn disconnect(&self) {
+        self.connected.send_if_modified(|val| {
+            if *val {
+                *val = false;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    pub(super) fn connect(&self) {
+        self.connected.send_if_modified(|val| {
+            if !*val {
+                *val = true;
+                true
+            } else {
+                false
+            }
+        });
+    }
 }
 
+pub type ConnectionStateHandle = Arc<Mutex<ConnectionState>>;
+
 impl<N: Node> WithVeilidConnection<N> {
-    pub fn new(node: N, state: Arc<Mutex<ConnectionState>>) -> Self {
+    pub fn new(node: N, state: ConnectionStateHandle) -> Self {
         let update_rx = node.subscribe_veilid_update();
         Self {
             node,
@@ -299,7 +323,7 @@ impl<N: Node> WithVeilidConnection<N> {
                         VeilidUpdate::Attachment(veilid_state_attachment) => {
                             if veilid_state_attachment.public_internet_ready {
                                 info!("connected: {:?}", veilid_state_attachment);
-                                state.connected.send_if_modified(|val| if !*val { *val = true; true } else { false });
+                                state.connect();
                                 return Ok(())
                             }
                             info!("disconnected: {:?}", veilid_state_attachment);
@@ -344,13 +368,14 @@ impl<
         let mut retries = 0;
         let actor = Arc::new(Mutex::new(actor_inner));
         loop {
-            {
+            let mut conn_rx = {
                 let st = state.lock().await;
                 if !*st.connected.borrow() {
                     self.disconnected(cancel.clone(), st).await?;
                     continue;
                 }
-            }
+                st.subscribe()
+            };
 
             let actor_handle = actor.clone();
             let actor_cancel = cancel.child_token();
@@ -359,7 +384,7 @@ impl<
                 actor_handle
                     .lock()
                     .await
-                    .run(actor_cancel.child_token(), actor_request_rx.clone())
+                    .run(actor_cancel, actor_request_rx.clone())
                     .await
             });
             select! {
@@ -383,14 +408,16 @@ impl<
                                     continue;
                                 }
                                 warn!("too many transient errors");
-                            } else if e.is_permanent() {
+                            } else if is_unrecoverable(&e) {
                                 cancel.cancel();
                                 return Err(e);
+                            } else if is_cancelled(&e) {
+                                return Ok(());
                             }
                             {
                                 if let Ok(st) = state.try_lock() {
                                     info!("marking disconnected");
-                                    st.connected.send_if_modified(|val| if *val { *val = false; true } else { false });
+                                    st.disconnect();
                                     exp_backoff.reset();
                                     retries = 0;
                                 }
@@ -405,7 +432,7 @@ impl<
                             if !veilid_state_attachment.public_internet_ready {
                                 if let Ok(st) = state.try_lock() {
                                     info!("marking disconnected: {:?}", veilid_state_attachment);
-                                    st.connected.send_if_modified(|val| if *val { *val = false; true } else { false });
+                                    st.disconnect();
                                     exp_backoff.reset();
                                     retries = 0;
                                 }
@@ -418,6 +445,10 @@ impl<
                         }
                         _ => {}
                     }
+                }
+                res = conn_rx.changed() => {
+                    // TODO: need to mark these unrecoverable and in the app join, tear down on any unrecoverable error!
+                    res?;
                 }
             }
         }

--- a/stigmerge-peer/src/block_fetcher.rs
+++ b/stigmerge-peer/src/block_fetcher.rs
@@ -136,6 +136,7 @@ pub enum Response {
     },
     FetchFailed {
         share_key: TypedKey,
+        target: Target,
         block: FileBlockFetch,
         err: Error,
     },
@@ -201,6 +202,7 @@ impl<P: Node + Send> Actor for BlockFetcher<P> {
                     Err(e) => (
                         Response::FetchFailed {
                             share_key,
+                            target,
                             block,
                             err: e,
                         },
@@ -392,6 +394,7 @@ mod tests {
                 share_key,
                 block: failed_block,
                 err,
+                ..
             } => {
                 assert_eq!(
                     share_key,

--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -9,6 +9,7 @@ pub mod have_resolver;
 pub mod node;
 pub mod peer_announcer;
 pub mod peer_resolver;
+mod peer_tracker;
 mod piece_map;
 pub mod piece_verifier;
 pub mod proto;
@@ -27,7 +28,7 @@ use tokio::sync::broadcast;
 use tracing::warn;
 use veilid_core::{RoutingContext, VeilidUpdate};
 
-pub use error::{is_cancelled, is_hangup, Error, Result};
+pub use error::{is_cancelled, is_unrecoverable, Error, Result};
 pub use node::{Node, Veilid};
 
 #[cfg(test)]

--- a/stigmerge-peer/src/node/veilid.rs
+++ b/stigmerge-peer/src/node/veilid.rs
@@ -1,7 +1,7 @@
 use std::{cmp::min, path::Path, sync::Arc};
 
 use tokio::sync::{broadcast, RwLock};
-use tracing::{debug, trace, warn};
+use tracing::{trace, warn};
 use veilid_core::{
     DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Target, ValueData,
     ValueSubkeyRangeSet, VeilidAPIError, VeilidUpdate,
@@ -53,7 +53,7 @@ impl Veilid {
             return Ok(rc.open_dht_record(dht_key, dht_owner_keypair).await?);
         }
         let o_cnt = header.subkeys() + 1;
-        debug!(o_cnt, "header subkeys");
+        trace!(o_cnt, "header subkeys");
         let dht_rec = rc
             .create_dht_record(DHTSchema::dflt(o_cnt)?, None, None)
             .await?;
@@ -139,7 +139,7 @@ impl Veilid {
     ) -> Result<()> {
         // Encode the header
         let header_bytes = header.encode()?;
-        debug!(
+        trace!(
             header_length = header_bytes.len(),
             key = key.to_string(),
             have_map_key = header.have_map().map(|hmr| hmr.key().to_string()),
@@ -165,7 +165,7 @@ impl Veilid {
                 return Ok(());
             }
             let count = min(ValueData::MAX_LEN, index_bytes.len() - offset);
-            debug!(offset, count, "writing index");
+            trace!(offset, count, "writing index");
             rc.set_dht_value(
                 dht_key.to_owned(),
                 subkey,
@@ -179,7 +179,7 @@ impl Veilid {
     }
 
     async fn read_header(&self, rc: &RoutingContext, key: &TypedKey) -> Result<Header> {
-        debug!(key = key.to_string());
+        trace!(key = key.to_string());
         let subkey_value = match rc.get_dht_value(key.to_owned(), 0, true).await? {
             Some(value) => value,
             None => {
@@ -191,7 +191,7 @@ impl Veilid {
             }
         };
         let header = Header::decode(subkey_value.data())?;
-        debug!(
+        trace!(
             header_length = subkey_value.data_size(),
             key = key.to_string(),
             have_map_key = header.have_map().map(|hmr| hmr.key().to_string()),
@@ -314,7 +314,7 @@ impl Node for Veilid {
         prior_route: Option<Target>,
         header: &Header,
     ) -> Result<(Target, Header)> {
-        debug!(key = key.to_string());
+        trace!(key = key.to_string());
         let rc = self.routing_context.read().await;
         self.release_prior_route(&rc, prior_route).await;
         let (announce_route, route_data) = rc.api().new_private_route().await?;
@@ -343,7 +343,7 @@ impl Node for Veilid {
         key: &TypedKey,
         prior_route: Option<Target>,
     ) -> Result<(Target, Header)> {
-        debug!(key = key.to_string());
+        trace!(key = key.to_string());
         let rc = self.routing_context.read().await;
         let _ = rc.open_dht_record(key.to_owned(), None).await?;
         self.release_prior_route(&rc, prior_route).await;
@@ -517,7 +517,7 @@ impl Node for Veilid {
             }
         };
 
-        debug!(
+        trace!(
             peer_share_key = peer_key.to_string(),
             have_map_key = have_map_ref.key().to_string()
         );
@@ -560,7 +560,7 @@ impl Node for Veilid {
             }
         };
 
-        debug!(
+        trace!(
             peer_share_key = peer_key.to_string(),
             peer_map_key = peer_map_ref.key().to_string()
         );

--- a/stigmerge-peer/src/peer_announcer.rs
+++ b/stigmerge-peer/src/peer_announcer.rs
@@ -8,6 +8,7 @@ use veilid_core::VeilidUpdate;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
+    error::Unrecoverable,
     node::TypedKey,
     proto::{self, Decoder},
     Node, Result,
@@ -189,7 +190,10 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     Response::Ok
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_announcer: send response")?;
             }
             Request::Redact {
                 key,
@@ -215,7 +219,10 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     Response::Ok
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "send response from peer announcer")?;
             }
             Request::Reset { mut response_tx } => {
                 let resp = match self
@@ -233,7 +240,10 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_announcer: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .context(Unrecoverable::new("send response from peer_announcer"))?;
             }
         }
 

--- a/stigmerge-peer/src/peer_resolver.rs
+++ b/stigmerge-peer/src/peer_resolver.rs
@@ -8,6 +8,7 @@ use veilid_core::{ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
+    error::Unrecoverable,
     node::TypedKey,
     proto::{self, Decoder, PeerInfo},
     Node, Result,
@@ -188,7 +189,10 @@ impl<P: Node> Actor for PeerResolver<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_resolver: send response")?;
             }
             Request::Watch {
                 key,
@@ -226,7 +230,10 @@ impl<P: Node> Actor for PeerResolver<P> {
                     },
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .with_context(|| "peer_resolver: send response")?;
             }
             Request::CancelWatch {
                 key,
@@ -253,7 +260,10 @@ impl<P: Node> Actor for PeerResolver<P> {
                     }
                 };
 
-                response_tx.send(resp).await.with_context(|| "peer_resolver: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .context(Unrecoverable::new("send response from peer resolver"))?;
             }
         }
 

--- a/stigmerge-peer/src/peer_tracker.rs
+++ b/stigmerge-peer/src/peer_tracker.rs
@@ -1,0 +1,215 @@
+use std::collections::{hash_map::Keys, HashMap};
+
+use moka::future::Cache;
+use tracing::debug;
+use veilid_core::Target;
+
+use crate::{error::is_route_invalid, node::TypedKey, types::FileBlockFetch, Error, Result};
+
+#[derive(Debug, Clone)]
+struct PeerStatus {
+    fetch_ok_count: u32,
+    fetch_err_count: u32,
+}
+
+impl PeerStatus {
+    fn score(&self) -> i32 {
+        TryInto::<i32>::try_into(self.fetch_ok_count).unwrap()
+            - TryInto::<i32>::try_into(self.fetch_err_count).unwrap()
+    }
+}
+
+impl Default for PeerStatus {
+    fn default() -> Self {
+        PeerStatus {
+            fetch_ok_count: 0,
+            fetch_err_count: 0,
+        }
+    }
+}
+
+pub struct PeerTracker {
+    targets: HashMap<TypedKey, Target>,
+    peer_status: Cache<TypedKey, PeerStatus>,
+}
+
+const MAX_TRACKED_PEERS: u64 = 64;
+
+impl PeerTracker {
+    pub fn new() -> Self {
+        PeerTracker {
+            targets: HashMap::new(),
+            peer_status: Cache::builder().max_capacity(MAX_TRACKED_PEERS).build(),
+        }
+    }
+
+    pub fn keys(&self) -> Keys<'_, TypedKey, Target> {
+        self.targets.keys()
+    }
+
+    pub async fn update(&mut self, key: TypedKey, target: Target) -> Option<Target> {
+        if !self.peer_status.contains_key(&key) {
+            self.peer_status
+                .insert(key.clone(), PeerStatus::default())
+                .await;
+        }
+        self.targets.insert(key, target)
+    }
+
+    pub fn contains(&self, key: &TypedKey) -> bool {
+        self.targets.contains_key(key)
+    }
+
+    pub async fn fetch_ok(&mut self, key: &TypedKey) {
+        let mut status = match self.peer_status.get(&key).await {
+            Some(status) => status,
+            None => PeerStatus::default(),
+        };
+        status.fetch_err_count = 0;
+        status.fetch_ok_count += 1;
+        self.peer_status.insert(key.clone(), status).await;
+    }
+
+    pub async fn fetch_err(&mut self, key: &TypedKey, err: &Error) {
+        let mut status = match self.peer_status.get(&key).await {
+            Some(status) => status,
+            None => PeerStatus::default(),
+        };
+        status.fetch_err_count += if is_route_invalid(&err) { 10 } else { 1 };
+        self.peer_status.insert(key.clone(), status).await;
+    }
+
+    pub async fn share_target(
+        &self,
+        _block: &FileBlockFetch,
+    ) -> Result<Option<(&TypedKey, &Target)>> {
+        // TODO: factor in have_map and block
+        let mut peers: Vec<(TypedKey, PeerStatus)> = self
+            .peer_status
+            .iter()
+            .map(|(key, status)| (*key, status))
+            .collect();
+        peers.sort_by(|(_, l_status), (_, r_status)| r_status.score().cmp(&l_status.score()));
+        if !peers.is_empty() {
+            return Ok(self.targets.get_key_value(&peers[0].0));
+        }
+        if self.targets.is_empty() {
+            Ok(None)
+        } else {
+            let (share_key, target) = self
+                .targets
+                .iter()
+                .nth(rand::random::<usize>() % self.targets.len())
+                .unwrap();
+            debug!("new status for peer key {share_key}");
+            self.peer_status
+                .insert(share_key.clone(), PeerStatus::default())
+                .await;
+            Ok(Some((share_key, target)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use veilid_core::{CryptoKey, CRYPTO_KIND_VLD0};
+
+    // Helper function to create a TypedKey for testing
+    fn create_typed_key(id: u8) -> TypedKey {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = id;
+        TypedKey::new(CRYPTO_KIND_VLD0, CryptoKey::from(key_bytes))
+    }
+
+    // Helper function to create a Target for testing
+    fn create_target(id: u8) -> Target {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = id;
+        Target::PrivateRoute(CryptoKey::new(key_bytes))
+    }
+
+    #[tokio::test]
+    async fn test_new_peer_tracker() {
+        let tracker = PeerTracker::new();
+        assert!(tracker.targets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_peer() {
+        let mut tracker = PeerTracker::new();
+        let key = create_typed_key(1);
+        let target = create_target(1);
+
+        // Update should return None for a new peer
+        let previous = tracker.update(key.clone(), target.clone()).await;
+        assert!(previous.is_none());
+
+        // Tracker should now contain the peer
+        assert!(tracker.contains(&key));
+
+        // Update with a new target should return the old target
+        let new_target = create_target(2);
+        let previous = tracker.update(key.clone(), new_target.clone()).await;
+        assert_eq!(previous.unwrap(), target);
+    }
+
+    #[tokio::test]
+    async fn test_peer_ranking() {
+        let mut tracker = PeerTracker::new();
+        let key1 = create_typed_key(1);
+        let key2 = create_typed_key(2);
+        let target1 = create_target(1);
+        let target2 = create_target(2);
+
+        // Add two peers
+        tracker.update(key1.clone(), target1.clone()).await;
+        tracker.update(key2.clone(), target2.clone()).await;
+
+        // Initially both peers have the same score
+        let block = FileBlockFetch {
+            file_index: 0,
+            piece_index: 0,
+            piece_offset: 0,
+            block_index: 0,
+        };
+
+        // Increase score for key1
+        tracker.fetch_ok(&key1).await;
+        tracker.fetch_ok(&key1).await;
+
+        // key1 should now be ranked higher
+        let result = tracker.share_target(&block).await.unwrap();
+        assert!(result.is_some());
+        let (share_key, _) = result.unwrap();
+        assert_eq!(share_key, &key1);
+    }
+
+    #[tokio::test]
+    async fn test_update_peer_route() {
+        let mut tracker = PeerTracker::new();
+        let key = create_typed_key(1);
+        let target1 = create_target(1);
+
+        // Add a peer
+        tracker.update(key.clone(), target1.clone()).await;
+
+        // Update the peer's route
+        let target2 = create_target(2);
+        tracker.update(key.clone(), target2.clone()).await;
+
+        // The share_target should now return the updated route
+        let block = FileBlockFetch {
+            file_index: 0,
+            piece_index: 0,
+            piece_offset: 0,
+            block_index: 0,
+        };
+
+        let share_target = tracker.share_target(&block).await.unwrap();
+        assert!(share_target.is_some());
+        let (share_key, share_target) = share_target.unwrap();
+        assert_eq!(share_key, &key);
+        assert_eq!(share_target, &target2);
+    }
+}

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -14,6 +14,7 @@ use veilid_core::VeilidUpdate;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
+    error::Unrecoverable,
     piece_map::PieceMap,
     proto::{self, BlockRequest, Decoder},
     types::{PieceState, ShareInfo},
@@ -147,7 +148,10 @@ impl<P: Node> Actor for Seeder<P> {
         match req {
             Request::HaveMap { mut response_tx } => {
                 let resp = Response::HaveMap(self.piece_map.clone());
-                response_tx.send(resp).await.with_context(|| "seeder: send response")?;
+                response_tx
+                    .send(resp)
+                    .await
+                    .context(Unrecoverable::new("send response from seeder"))?;
                 Ok(())
             }
         }

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -9,6 +9,7 @@ use veilid_core::{Target, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
+    error::Unrecoverable,
     node::TypedKey,
     proto::Header,
     Node, Result,
@@ -162,7 +163,10 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
             Err(_) => Response::NotAvailable,
         };
 
-        req.response_tx().send(response).await.with_context(|| "share_announcer: send response")?;
+        req.response_tx()
+            .send(response)
+            .await
+            .context(Unrecoverable::new("send response from share announcer"))?;
 
         Ok(())
     }

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -4,15 +4,6 @@ use anyhow::{bail, Error, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use path_absolutize::Absolutize;
 use stigmerge_fileindex::Indexer;
-use tokio::{
-    select,
-    sync::{watch, RwLock},
-    task::JoinSet,
-    time::sleep,
-};
-use tokio_util::sync::CancellationToken;
-use veilid_core::TypedKey;
-
 use stigmerge_peer::{
     actor::{ConnectionState, Operator, ResponseChannel, UntilCancelled, WithVeilidConnection},
     block_fetcher::BlockFetcher,
@@ -28,7 +19,15 @@ use stigmerge_peer::{
     share_resolver::{self, ShareResolver},
     types::ShareInfo,
 };
+use tokio::{
+    select, spawn,
+    sync::{watch, RwLock},
+    task::JoinSet,
+    time::sleep,
+};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
+use veilid_core::TypedKey;
 
 use crate::{cli::Commands, initialize_stdout_logging, initialize_ui_logging, Cli};
 
@@ -105,7 +104,7 @@ impl App {
                     }
                     res = conn_state_rx.changed() => {
                         res?;
-                        if *conn_state_rx.borrow() {
+                        if *conn_state_rx.borrow_and_update() {
                             conn_progress_bar.disable_steady_tick();
                             conn_progress_bar.set_style(ProgressStyle::with_template("{prefix} {msg}")?);
                             conn_progress_bar.set_message("Connected to Veilid network");
@@ -298,7 +297,7 @@ impl App {
 
         let fetcher = Fetcher::new(node.clone(), share.clone(), fetcher_clients);
         self.add_fetch_progress(&cancel, &mut tasks, fetcher.subscribe_fetcher_status())?;
-        tasks.spawn(fetcher.run(cancel.clone()));
+        let fetcher_task = spawn(fetcher.run(cancel.clone()));
 
         // Set up seeder
         let seeder_clients = seeder::Clients {
@@ -310,7 +309,7 @@ impl App {
         let seeder_op = Operator::new(
             cancel.clone(),
             seeder,
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
+            WithVeilidConnection::new(node.clone(), conn_state),
         );
         tasks.spawn(async move { seeder_op.join().await });
 
@@ -329,18 +328,34 @@ impl App {
             share_key.to_string()
         ));
 
-        // Keep seeding until ctrl-c
-        select! {
+        // Keep seeding until ctrl-c or fetcher exits
+        let res = select! {
             _ = tokio::signal::ctrl_c() => {
                 info!("Received ctrl-c, shutting down...");
                 cancel.cancel();
+                Ok(())
             }
-            _ = tasks.join_all() => {
-                info!("tasks complete");
+            join_res = fetcher_task => {
+                cancel.cancel();
+                match join_res {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(e)) => {
+                        error!("fetcher: {}", e);
+                        Err(e)
+                    }
+                    Err(e) => {
+                        error!("join fetcher: {}", e);
+                        Err(e.into())
+                    }
+                }
             }
-        }
-
-        Ok(())
+        };
+        tasks
+            .join_all()
+            .await
+            .into_iter()
+            .collect::<Result<(), _>>()?;
+        res
     }
 
     fn add_fetch_progress(

--- a/stigmerge/src/bin/stigmerge.rs
+++ b/stigmerge/src/bin/stigmerge.rs
@@ -7,6 +7,7 @@ use stigmerge::{App, Cli};
 
 #[cfg(target_os = "android")]
 use jni::{objects::JObject, InitArgsBuilder, JNIVersion, JavaVM};
+use stigmerge_peer::is_cancelled;
 
 /// Initialize native platform-specific stuff.
 ///
@@ -68,11 +69,16 @@ fn init_native() -> Result<()> {
 #[tokio::main]
 async fn main() -> Result<()> {
     init_native()?;
-    if let Err(e) = tokio_main().await {
-        eprintln!("{} error: Something went wrong", env!("CARGO_PKG_NAME"));
-        Err(e)
-    } else {
-        Ok(())
+    match tokio_main().await {
+        Err(e) => {
+            if !is_cancelled(&e) {
+                eprintln!("{} error: Something went wrong", env!("CARGO_PKG_NAME"));
+                Err(e)
+            } else {
+                Ok(())
+            }
+        }
+        ok => ok,
     }
 }
 


### PR DESCRIPTION
Channel send and receive errors are generally unrecoverable in stigmerge. If they happen, it means there's a serious problem where an actor or its subscription was dropped in an unexpected way.

The fetcher has a few other unrecoverable errors; if it can't access the local filesystem to diff the have vs want share, the application cannot recover and should shut down on error.

Generally any fetcher state handling method should return an error only if it needs to shut down. So transient errors within the fetcher, such as a failure to select viable peers, should not be returned from the fetch loop.

In the event a fetcher hits the bottom and all peers are unviable, the fetcher initiates a veilid disconnect.