### PR TITLE
chore: upgrade to veilid-core 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,18 +2109,18 @@ dependencies = [
 
 [[package]]
 name = "keyvaluedb"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fe4850c4103a92a7bd14a56ecbe413c27f8c89ea642cb4753b310c30dff812"
+checksum = "ad0c34a6c4cdaa09c7de9d712b7bbda2a111ebba238751696b522e261b5501e0"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "keyvaluedb-memorydb"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e8d196e170cdf21ee4fb0ff779278ca24253c10abee1a49914a893dce71097"
+checksum = "462f214495626d3245889a431c608f6791a10623735593cccfc9cbf4c72a73f1"
 dependencies = [
  "keyvaluedb",
  "parking_lot",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "keyvaluedb-sqlite"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4d3df76ca45b92891e22fbd0a0928d2ef848a65051d5bd2da43ed1c0dfeb6f"
+checksum = "d69f492eb8a28913fcb3b741b94abf3986933efab9a305488237407052e002e8"
 dependencies = [
  "hex",
  "keyvaluedb",
@@ -2141,18 +2141,16 @@ dependencies = [
 
 [[package]]
 name = "keyvaluedb-web"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351f750d6c87e6af74cdead18c33bb14fa47882787873bc05faa0002078cb9e5"
+checksum = "81293b271c88dc807e3e9eec9e31bc62c2dff6b9938ae2c5fc77f73f451aae8f"
 dependencies = [
- "async-lock 2.8.0",
  "flume",
  "futures",
  "js-sys",
  "keyvaluedb",
  "keyvaluedb-memorydb",
  "log",
- "parking_lot",
  "send_wrapper 0.6.0",
  "wasm-bindgen",
  "web-sys",
@@ -4238,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-core"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6175b8f44d6bd1574685a66a2a701203eec17f3e2efc58720a473140bd540e55"
+checksum = "aed956d750cfa4bdaa3838fcb069bc6c07fda778f7a79ebb8b752eb1c73987ba"
 dependencies = [
  "argon2",
  "async-tls",
@@ -4357,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0b0a53fd202c34b18f16034375164b6ba076dc0e0e29b1bd3044357afecde4"
+checksum = "f2f8ea5024138071fcb290441fa3cbb98d1ae37109764b65a48af4dadb8c1ae5"
 dependencies = [
  "android_logger 0.13.3",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1.40", features = ["full"] }
 tokio-util = { version = "0.7" }
 tracing = { version = "0.1", features = ["log", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-veilid-core = { version = "0.4.6" }
+veilid-core = { version = "0.4.7" }
 
 [profile.release]
 strip = true

--- a/stigmerge-peer/examples/fetch_block.rs
+++ b/stigmerge-peer/examples/fetch_block.rs
@@ -51,7 +51,7 @@ use stigmerge_peer::node::Veilid;
 use stigmerge_peer::share_resolver::{self, ShareResolver};
 use stigmerge_peer::types::FileBlockFetch;
 use stigmerge_peer::Error;
-use veilid_core::TypedKey;
+use veilid_core::TypedRecordKey;
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {
@@ -92,7 +92,7 @@ async fn main() -> std::result::Result<(), Error> {
     );
 
     // Parse share key
-    let key: TypedKey = share_key.parse()?;
+    let key: TypedRecordKey = share_key.parse()?;
 
     // Create a temporary directory for the block fetcher
     let temp_dir = tempfile::tempdir()?;

--- a/stigmerge-peer/examples/fetcher_resolver.rs
+++ b/stigmerge-peer/examples/fetcher_resolver.rs
@@ -42,7 +42,7 @@ use stigmerge_peer::piece_verifier::PieceVerifier;
 use stigmerge_peer::share_resolver::{self, ShareResolver};
 use stigmerge_peer::types::ShareInfo;
 use stigmerge_peer::Error;
-use veilid_core::TypedKey;
+use veilid_core::TypedRecordKey;
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Error> {
@@ -74,7 +74,7 @@ async fn main() -> std::result::Result<(), Error> {
     );
 
     // Parse share key and want_index_digest
-    let key: TypedKey = share_key.parse()?;
+    let key: TypedRecordKey = share_key.parse()?;
     let want_index_digest = hex::decode(want_index_digest)?;
     let want_index_digest: [u8; 32] = want_index_digest
         .try_into()

--- a/stigmerge-peer/examples/peer_announce.rs
+++ b/stigmerge-peer/examples/peer_announce.rs
@@ -26,7 +26,7 @@ use tokio::select;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use veilid_core::{TypedKey, VeilidUpdate};
+use veilid_core::{TypedRecordKey, VeilidUpdate};
 
 use stigmerge_fileindex::Indexer;
 use stigmerge_peer::actor::{ConnectionState, Operator, ResponseChannel, WithVeilidConnection};
@@ -105,7 +105,7 @@ async fn main() -> std::result::Result<(), Error> {
 
     // Announce initial peer keys
     for peer_share_key_str in args.peer_keys {
-        let peer_share_key = TypedKey::from_str(&peer_share_key_str)
+        let peer_share_key = TypedRecordKey::from_str(&peer_share_key_str)
             .map_err(|e| anyhow::anyhow!("invalid peer share key {}: {}", peer_share_key_str, e))?;
 
         match peer_announcer_op

--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -64,7 +64,7 @@ use stigmerge_peer::seeder::{self, Seeder};
 use stigmerge_peer::share_resolver::{self, ShareResolver};
 use stigmerge_peer::types::ShareInfo;
 use stigmerge_peer::{Error, Result};
-use veilid_core::TypedKey;
+use veilid_core::TypedRecordKey;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -119,7 +119,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
     let mut want_index = None;
     if let Some(ref want_index_digest) = args.want_index_digest {
         for share_key_str in args.share_keys.iter() {
-            let share_key: TypedKey = share_key_str.parse()?;
+            let share_key: TypedRecordKey = share_key_str.parse()?;
             let want_index_digest = hex::decode(want_index_digest.clone())?;
             let want_index_digest: [u8; 32] = want_index_digest
                 .try_into()

--- a/stigmerge-peer/src/fetcher.rs
+++ b/stigmerge-peer/src/fetcher.rs
@@ -9,11 +9,10 @@ use tokio::time::interval;
 use tokio::{select, try_join};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace, warn};
-use veilid_core::Target;
+use veilid_core::{Target, TypedRecordKey};
 
 use crate::actor::ResponseChannel;
 use crate::error::Unrecoverable;
-use crate::node::TypedKey;
 use crate::peer_tracker::PeerTracker;
 use crate::types::{FileBlockFetch, PieceState, ShareInfo};
 use crate::{actor::Operator, have_announcer};
@@ -49,9 +48,9 @@ pub struct Clients {
     pub piece_verifier: Operator<piece_verifier::Request>,
     pub have_announcer: Operator<have_announcer::Request>,
     pub share_resolver: Operator<share_resolver::Request>,
-    pub share_target_rx: flume::Receiver<(TypedKey, Target)>,
+    pub share_target_rx: flume::Receiver<(TypedRecordKey, Target)>,
     pub peer_resolver: Operator<peer_resolver::Request>,
-    pub discovered_peers_rx: flume::Receiver<(TypedKey, proto::PeerInfo)>,
+    pub discovered_peers_rx: flume::Receiver<(TypedRecordKey, proto::PeerInfo)>,
 }
 
 #[derive(Debug)]

--- a/stigmerge-peer/src/have_announcer.rs
+++ b/stigmerge-peer/src/have_announcer.rs
@@ -3,12 +3,12 @@ use std::{fmt, ops::Deref, sync::Arc, time::Duration};
 use anyhow::Context;
 use tokio::{select, sync::RwLock};
 use tokio_util::sync::CancellationToken;
+use veilid_core::TypedRecordKey;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
     error::Result,
     is_cancelled,
-    node::TypedKey,
     piece_map::PieceMap,
     Node,
 };
@@ -21,14 +21,14 @@ use crate::{
 #[derive(Clone)]
 pub struct HaveAnnouncer<N: Node> {
     node: N,
-    key: TypedKey,
+    key: TypedRecordKey,
     pieces_map: Arc<RwLock<PieceMap>>,
     announce_interval: Duration,
 }
 
 impl<N: Node> HaveAnnouncer<N> {
     /// Create a new have_announcer service.
-    pub fn new(node: N, key: TypedKey) -> Self {
+    pub fn new(node: N, key: TypedRecordKey) -> Self {
         Self {
             node,
             key,
@@ -178,7 +178,7 @@ mod tests {
     };
 
     use tokio_util::sync::CancellationToken;
-    use veilid_core::TypedKey;
+    use veilid_core::TypedRecordKey;
 
     use crate::{
         actor::{OneShot, Operator, ResponseChannel},
@@ -197,16 +197,17 @@ mod tests {
         let recorded_have_map_clone = recorded_have_map.clone();
         let recorded_key_clone = recorded_key.clone();
 
-        node.announce_have_map_result =
-            Arc::new(Mutex::new(move |key: TypedKey, have_map: &PieceMap| {
+        node.announce_have_map_result = Arc::new(Mutex::new(
+            move |key: TypedRecordKey, have_map: &PieceMap| {
                 *recorded_have_map_clone.write().unwrap() = Some(have_map.clone());
                 *recorded_key_clone.write().unwrap() = Some(key.clone());
                 Ok(())
-            }));
+            },
+        ));
 
         // Create a test key and channel
-        let test_key =
-            TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M").expect("key");
+        let test_key = TypedRecordKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("key");
 
         // Create have announcer with a short announce interval
         let mut have_announcer = HaveAnnouncer::new(node.clone(), test_key.clone());
@@ -252,15 +253,16 @@ mod tests {
         let recorded_have_map = Arc::new(RwLock::new(None));
 
         let recorded_have_map_clone = recorded_have_map.clone();
-        node.announce_have_map_result =
-            Arc::new(Mutex::new(move |_key: TypedKey, have_map: &PieceMap| {
+        node.announce_have_map_result = Arc::new(Mutex::new(
+            move |_key: TypedRecordKey, have_map: &PieceMap| {
                 *recorded_have_map_clone.write().unwrap() = Some(have_map.clone());
                 Ok(())
-            }));
+            },
+        ));
 
         // Create a test key and channel
-        let test_key =
-            TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M").expect("key");
+        let test_key = TypedRecordKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("key");
         let mut have_announcer = HaveAnnouncer::new(node.clone(), test_key);
         have_announcer.announce_interval = std::time::Duration::from_millis(1);
         let cancel = CancellationToken::new();
@@ -304,15 +306,16 @@ mod tests {
         let recorded_have_map = Arc::new(RwLock::new(None));
 
         let recorded_have_map_clone = recorded_have_map.clone();
-        node.announce_have_map_result =
-            Arc::new(Mutex::new(move |_key: TypedKey, have_map: &PieceMap| {
+        node.announce_have_map_result = Arc::new(Mutex::new(
+            move |_key: TypedRecordKey, have_map: &PieceMap| {
                 *recorded_have_map_clone.write().unwrap() = Some(have_map.clone());
                 Ok(())
-            }));
+            },
+        ));
 
         // Create a test key and channel
-        let test_key =
-            TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M").expect("key");
+        let test_key = TypedRecordKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("key");
 
         let mut have_announcer = HaveAnnouncer::new(node.clone(), test_key);
         let cancel = CancellationToken::new();

--- a/stigmerge-peer/src/node/mod.rs
+++ b/stigmerge-peer/src/node/mod.rs
@@ -3,15 +3,13 @@ use std::{future::Future, path::Path};
 
 use backoff::ExponentialBackoff;
 use tokio::sync::broadcast;
-use veilid_core::{CryptoKey, CryptoTyped, OperationId, Target, ValueSubkeyRangeSet, VeilidUpdate};
+use veilid_core::{OperationId, Target, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 
 use stigmerge_fileindex::Index;
 
 use crate::piece_map::PieceMap;
 use crate::proto::PeerInfo;
 use crate::{proto::Header, Result};
-
-pub type TypedKey = CryptoTyped<CryptoKey>;
 
 pub trait Node: Clone + Send {
     fn subscribe_veilid_update(&self) -> broadcast::Receiver<VeilidUpdate>;
@@ -22,22 +20,22 @@ pub trait Node: Clone + Send {
     fn announce_index(
         &mut self,
         index: &Index,
-    ) -> impl std::future::Future<Output = Result<(TypedKey, Target, Header)>> + Send;
+    ) -> impl std::future::Future<Output = Result<(TypedRecordKey, Target, Header)>> + Send;
     fn announce_route(
         &mut self,
-        key: &TypedKey,
+        key: &TypedRecordKey,
         prior_route: Option<Target>,
         header: &Header,
     ) -> impl std::future::Future<Output = Result<(Target, Header)>> + Send;
 
     fn resolve_route_index(
         &mut self,
-        key: &TypedKey,
+        key: &TypedRecordKey,
         root: &Path,
     ) -> impl std::future::Future<Output = Result<(Target, Header, Index)>> + Send;
     fn resolve_route(
         &mut self,
-        key: &TypedKey,
+        key: &TypedRecordKey,
         prior_route: Option<Target>,
     ) -> impl Future<Output = Result<(Target, Header)>> + Send;
 
@@ -57,42 +55,42 @@ pub trait Node: Clone + Send {
     fn request_advertise_peer(
         &mut self,
         target: &Target,
-        key: &TypedKey,
+        key: &TypedRecordKey,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn watch(
         &mut self,
-        key: TypedKey,
+        key: TypedRecordKey,
         values: ValueSubkeyRangeSet,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn cancel_watch(
         &mut self,
-        key: &TypedKey,
+        key: &TypedRecordKey,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn merge_have_map(
         &mut self,
-        key: TypedKey,
+        key: TypedRecordKey,
         subkeys: ValueSubkeyRangeSet,
         have_map: &mut PieceMap,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn announce_have_map(
         &mut self,
-        key: TypedKey,
+        key: TypedRecordKey,
         have_map: &PieceMap,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     fn resolve_have_map(
         &mut self,
-        peer_key: &TypedKey,
+        peer_key: &TypedRecordKey,
     ) -> impl std::future::Future<Output = Result<PieceMap>> + Send;
 
     fn announce_peer(
         &mut self,
         payload_digest: &[u8],
-        peer_key: Option<TypedKey>,
+        peer_key: Option<TypedRecordKey>,
         subkey: u16,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
@@ -104,7 +102,7 @@ pub trait Node: Clone + Send {
 
     fn resolve_peers(
         &mut self,
-        peer_key: &TypedKey,
+        peer_key: &TypedRecordKey,
     ) -> impl std::future::Future<Output = Result<Vec<PeerInfo>>> + Send;
 }
 

--- a/stigmerge-peer/src/proto/header.rs
+++ b/stigmerge-peer/src/proto/header.rs
@@ -3,9 +3,7 @@ use capnp::{
     serialize,
 };
 use stigmerge_fileindex::Index;
-use veilid_core::ValueData;
-
-use crate::node::TypedKey;
+use veilid_core::{TypedRecordKey, ValueData};
 
 use super::{
     stigmerge_capnp::header, Decoder, Digest, Encoder, Error, PublicKey, Result, MAX_INDEX_BYTES,
@@ -126,7 +124,7 @@ impl Decoder for Header {
                     key[16..24].clone_from_slice(&key_reader.get_p2().to_be_bytes()[..]);
                     key[24..32].clone_from_slice(&key_reader.get_p3().to_be_bytes()[..]);
                     header = header.with_have_map(HaveMapRef {
-                        key: TypedKey::new(kind, key.into()),
+                        key: TypedRecordKey::new(kind, key.into()),
                         subkeys: have_map_ref_reader.get_subkeys(),
                     });
                 }
@@ -145,7 +143,7 @@ impl Decoder for Header {
                     key[16..24].clone_from_slice(&key_reader.get_p2().to_be_bytes()[..]);
                     key[24..32].clone_from_slice(&key_reader.get_p3().to_be_bytes()[..]);
                     header = header.with_peer_map(PeerMapRef {
-                        key: TypedKey::new(typed_key_reader.get_kind().into(), key.into()),
+                        key: TypedRecordKey::new(typed_key_reader.get_kind().into(), key.into()),
                         subkeys: peer_map_ref_reader.get_subkeys(),
                     });
                 }
@@ -158,16 +156,16 @@ impl Decoder for Header {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct HaveMapRef {
-    key: TypedKey,
+    key: TypedRecordKey,
     subkeys: u16,
 }
 
 impl HaveMapRef {
-    pub fn new(key: TypedKey, subkeys: u16) -> Self {
+    pub fn new(key: TypedRecordKey, subkeys: u16) -> Self {
         Self { key, subkeys }
     }
 
-    pub fn key(&self) -> &TypedKey {
+    pub fn key(&self) -> &TypedRecordKey {
         &self.key
     }
 
@@ -178,16 +176,16 @@ impl HaveMapRef {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct PeerMapRef {
-    key: TypedKey,
+    key: TypedRecordKey,
     subkeys: u16,
 }
 
 impl PeerMapRef {
-    pub fn new(key: TypedKey, subkeys: u16) -> Self {
+    pub fn new(key: TypedRecordKey, subkeys: u16) -> Self {
         Self { key, subkeys }
     }
 
-    pub fn key(&self) -> &TypedKey {
+    pub fn key(&self) -> &TypedRecordKey {
         &self.key
     }
 
@@ -284,9 +282,8 @@ mod tests {
     use std::path::PathBuf;
 
     use stigmerge_fileindex::{Index, PayloadSpec};
-    use veilid_core::CRYPTO_KIND_VLD0;
+    use veilid_core::{CryptoKind, TypedRecordKey};
 
-    use crate::node::TypedKey;
     use crate::proto::{Decoder, Encoder, HaveMapRef, Header, PeerMapRef};
 
     #[test]
@@ -312,8 +309,8 @@ mod tests {
         let route_data = vec![1u8, 2u8, 3u8, 4u8];
 
         // Create TypedKeys for peer map and have map
-        let peer_key = TypedKey::new(CRYPTO_KIND_VLD0, [0xaa; 32].into());
-        let have_key = TypedKey::new(CRYPTO_KIND_VLD0, [0xbb; 32].into());
+        let peer_key = TypedRecordKey::new(CryptoKind::default(), [0xaa; 32].into());
+        let have_key = TypedRecordKey::new(CryptoKind::default(), [0xbb; 32].into());
 
         // Create the peer map ref and have map ref
         let peer_map_ref = PeerMapRef::new(peer_key, 10);

--- a/stigmerge-peer/src/proto/peerinfo.rs
+++ b/stigmerge-peer/src/proto/peerinfo.rs
@@ -2,29 +2,29 @@ use capnp::{
     message::{self, ReaderOptions},
     serialize,
 };
-use veilid_core::{Timestamp, TypedKey};
+use veilid_core::{Timestamp, TypedRecordKey};
 
 use super::{stigmerge_capnp::peer_info, Decoder, Encoder, PublicKey};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct PeerInfo {
-    key: TypedKey,
+    key: TypedRecordKey,
     updated_at: Timestamp,
 }
 
 impl PeerInfo {
-    pub fn new(key: TypedKey) -> Self {
+    pub fn new(key: TypedRecordKey) -> Self {
         Self {
             key,
             updated_at: Timestamp::now(),
         }
     }
 
-    pub fn new_updated_at(key: TypedKey, updated_at: Timestamp) -> Self {
+    pub fn new_updated_at(key: TypedRecordKey, updated_at: Timestamp) -> Self {
         Self { key, updated_at }
     }
 
-    pub fn key(&self) -> &TypedKey {
+    pub fn key(&self) -> &TypedRecordKey {
         &self.key
     }
 
@@ -68,7 +68,7 @@ impl Decoder for PeerInfo {
         key[24..32].clone_from_slice(&key_reader.get_p3().to_be_bytes()[..]);
 
         Ok(Self {
-            key: TypedKey::new(typed_key_reader.get_kind().into(), key.into()),
+            key: TypedRecordKey::new(typed_key_reader.get_kind().into(), key.into()),
             updated_at: Timestamp::new(peer_info_reader.get_updated_at()),
         })
     }
@@ -78,13 +78,14 @@ impl Decoder for PeerInfo {
 mod tests {
     use std::str::FromStr;
 
-    use veilid_core::TypedKey;
+    use veilid_core::TypedRecordKey;
 
     use crate::proto::{Decoder, Encoder, PeerInfo};
 
     #[test]
     fn test_encode_decode() {
-        let key = TypedKey::from_str("VLD0:mluySonu8GKEd2AYTY0KB8y7upLHlXwm4movvucbfoQ").unwrap();
+        let key =
+            TypedRecordKey::from_str("VLD0:mluySonu8GKEd2AYTY0KB8y7upLHlXwm4movvucbfoQ").unwrap();
         let peer_info = PeerInfo::new(key);
         let encoded = peer_info.encode().unwrap();
         let decoded = PeerInfo::decode(&encoded).unwrap();

--- a/stigmerge-peer/src/proto/request.rs
+++ b/stigmerge-peer/src/proto/request.rs
@@ -1,8 +1,8 @@
-use crate::node::TypedKey;
 use capnp::{
     message::{self, ReaderOptions},
     serialize,
 };
+use veilid_core::TypedRecordKey;
 
 use super::{
     stigmerge_capnp::request, Decoder, Encoder, Error, PublicKey, Result, MAX_INDEX_BYTES,
@@ -22,7 +22,7 @@ pub struct BlockRequest {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct AdvertisePeerRequest {
-    pub key: TypedKey,
+    pub key: TypedRecordKey,
 }
 
 impl Encoder for Request {
@@ -93,7 +93,7 @@ impl Decoder for Request {
                 }
 
                 Ok(Request::AdvertisePeer(AdvertisePeerRequest {
-                    key: TypedKey::new(typed_key_reader.get_kind().into(), key.into()),
+                    key: TypedRecordKey::new(typed_key_reader.get_kind().into(), key.into()),
                 }))
             }
             Err(e) => Err(e.into()),
@@ -103,9 +103,7 @@ impl Decoder for Request {
 
 #[cfg(test)]
 mod tests {
-    use veilid_core::CRYPTO_KIND_VLD0;
-
-    use crate::node::TypedKey;
+    use veilid_core::CryptoKind;
 
     use super::*;
 
@@ -119,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_advertise_peer() {
-        let key = TypedKey::new(CRYPTO_KIND_VLD0, [0xaa; 32].into());
+        let key = TypedRecordKey::new(CryptoKind::default(), [0xaa; 32].into());
         let message = Request::AdvertisePeer(AdvertisePeerRequest { key });
         let encoded = message.encode().unwrap();
         let decoded = Request::decode(&encoded).unwrap();

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -195,7 +195,7 @@ mod tests {
 
     use tokio::{sync::mpsc, time};
     use tokio_util::sync::CancellationToken;
-    use veilid_core::{OperationId, TypedKey, VeilidAppCall};
+    use veilid_core::{OperationId, TypedRecordKey, VeilidAppCall};
 
     use crate::{
         actor::{OneShot, Operator, ResponseChannel},
@@ -245,8 +245,8 @@ mod tests {
             },
         ));
 
-        let fake_key =
-            TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M").expect("key");
+        let fake_key = TypedRecordKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("key");
 
         // Create share info
         let share_info = ShareInfo {
@@ -363,8 +363,8 @@ mod tests {
             },
         ));
 
-        let fake_key =
-            TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M").expect("key");
+        let fake_key = TypedRecordKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("key");
 
         // Create share info
         let share_info = ShareInfo {

--- a/stigmerge-peer/src/types.rs
+++ b/stigmerge-peer/src/types.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
 
 use stigmerge_fileindex::{Index, BLOCK_SIZE_BYTES, PIECE_SIZE_BLOCKS, PIECE_SIZE_BYTES};
+use veilid_core::TypedRecordKey;
 
-use crate::{node::TypedKey, proto::Header};
+use crate::proto::Header;
 
 #[derive(Debug, Clone)]
 pub struct ShareInfo {
-    pub key: TypedKey,
+    pub key: TypedRecordKey,
     pub header: Header,
     pub want_index: Index,
     pub want_index_digest: [u8; 32],

--- a/stigmerge-peer/src/veilid_config.rs
+++ b/stigmerge-peer/src/veilid_config.rs
@@ -1,7 +1,8 @@
 use std::{env, str::FromStr};
 
 use veilid_core::{
-    ConfigCallbackReturn, FourCC, TypedKey, TypedKeyGroup, TypedSecretGroup, VeilidAPIError,
+    ConfigCallbackReturn, TypedNodeIdGroup, TypedPublicKey, TypedSecretKeyGroup, VeilidAPIError,
+    VeilidCapability,
 };
 
 pub fn node_addr() -> Option<String> {
@@ -19,7 +20,7 @@ pub fn callback(state_dir: String, ns: Option<String>, key: String) -> ConfigCal
         } else {
             Box::<String>::default()
         }),
-        "capabilities.disable" => Ok(Box::<Vec<FourCC>>::default()),
+        "capabilities.disable" => Ok(Box::<Vec<VeilidCapability>>::default()),
         "table_store.directory" => Ok(Box::new(get_table_store_path(&state_dir))),
         "table_store.delete" => Ok(Box::new(false)),
         "block_store.directory" => Ok(Box::new(get_block_store_path(&state_dir))),
@@ -46,15 +47,15 @@ pub fn callback(state_dir: String, ns: Option<String>, key: String) -> ConfigCal
         "network.reverse_connection_receipt_time_ms" => Ok(Box::new(5_000u32)),
         "network.hole_punch_receipt_time_ms" => Ok(Box::new(5_000u32)),
         "network.network_key_password" => Ok(Box::new(Option::<String>::None)),
-        "network.routing_table.node_id" => Ok(Box::new(TypedKeyGroup::new())),
-        "network.routing_table.node_id_secret" => Ok(Box::new(TypedSecretGroup::new())),
+        "network.routing_table.node_id" => Ok(Box::new(TypedNodeIdGroup::new())),
+        "network.routing_table.node_id_secret" => Ok(Box::new(TypedSecretKeyGroup::new())),
         "network.routing_table.bootstrap" => {
             Ok(Box::new(vec!["bootstrap-v1.veilid.net".to_string()]))
         }
         "network.routing_table.bootstrap_keys" => Ok(Box::new(vec![
-            TypedKey::from_str("VLD0:Vj0lKDdUQXmQ5Ol1SZdlvXkBHUccBcQvGLN9vbLSI7k").unwrap(),
-            TypedKey::from_str("VLD0:QeQJorqbXtC7v3OlynCZ_W3m76wGNeB5NTF81ypqHAo").unwrap(),
-            TypedKey::from_str("VLD0:QNdcl-0OiFfYVj9331XVR6IqZ49NG-E18d5P7lwi4TA").unwrap(),
+            TypedPublicKey::from_str("VLD0:Vj0lKDdUQXmQ5Ol1SZdlvXkBHUccBcQvGLN9vbLSI7k").unwrap(),
+            TypedPublicKey::from_str("VLD0:QeQJorqbXtC7v3OlynCZ_W3m76wGNeB5NTF81ypqHAo").unwrap(),
+            TypedPublicKey::from_str("VLD0:QNdcl-0OiFfYVj9331XVR6IqZ49NG-E18d5P7lwi4TA").unwrap(),
         ])),
         "network.routing_table.limit_over_attached" => Ok(Box::new(64u32)),
         "network.routing_table.limit_fully_attached" => Ok(Box::new(32u32)),

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -27,7 +27,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
-use veilid_core::TypedKey;
+use veilid_core::TypedRecordKey;
 
 use crate::{cli::Commands, initialize_stdout_logging, initialize_ui_logging, Cli};
 
@@ -168,7 +168,7 @@ impl App {
                 n_fetchers = *fetchers;
                 for share_key_str in share_keys.iter() {
                     debug!("resolving share key: {share_key_str}");
-                    let share_key: TypedKey = share_key_str.parse()?;
+                    let share_key: TypedRecordKey = share_key_str.parse()?;
                     let want_index_digest = match index_digest {
                         Some(digest_string) => {
                             let digest = hex::decode(digest_string)?;


### PR DESCRIPTION
veilid-core 0.4.7 made some significant refactoring changes around key types. For the better, key usage intent is a lot clearer.