### PR TITLE
fix: consistency in cancellation and fetcher done state

### DIFF
--- a/stigmerge-peer/examples/peer_announce.rs
+++ b/stigmerge-peer/examples/peer_announce.rs
@@ -242,7 +242,6 @@ async fn main() -> std::result::Result<(), Error> {
                                 }
                                 _ => {}  // Ignore other request types
                             }
-
                         }
                         VeilidUpdate::Shutdown => {
                             cancel.cancel();

--- a/stigmerge-peer/src/block_fetcher.rs
+++ b/stigmerge-peer/src/block_fetcher.rs
@@ -332,7 +332,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("fetcher task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -408,6 +408,6 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("fetcher task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/block_fetcher.rs
+++ b/stigmerge-peer/src/block_fetcher.rs
@@ -16,7 +16,7 @@ use tracing::trace;
 use veilid_core::{Target, TypedRecordKey};
 
 use crate::actor::{Actor, Respondable, ResponseChannel};
-use crate::error::{is_io, is_proto, is_route_invalid, Result, Transient};
+use crate::error::{is_io, is_proto, is_route_invalid, CancelError, Result, Transient};
 use crate::is_cancelled;
 use crate::node::Node;
 use crate::Error;
@@ -154,7 +154,7 @@ impl<P: Node + Send> Actor for BlockFetcher<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("block_fetcher: receive request"))?;

--- a/stigmerge-peer/src/have_announcer.rs
+++ b/stigmerge-peer/src/have_announcer.rs
@@ -243,7 +243,7 @@ mod tests {
         assert!(!recorded_map.get(43), "Other piece indices should be clear");
 
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -296,7 +296,7 @@ mod tests {
         assert!(!recorded_map.get(43), "Other piece indices should be clear");
 
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -352,6 +352,6 @@ mod tests {
         assert!(!recorded_map.get(43), "Other piece indices should be clear");
 
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/have_announcer.rs
+++ b/stigmerge-peer/src/have_announcer.rs
@@ -7,7 +7,7 @@ use veilid_core::TypedRecordKey;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::Result,
+    error::{CancelError, Result},
     is_cancelled,
     piece_map::PieceMap,
     Node,
@@ -117,7 +117,7 @@ impl<P: Node> Actor for HaveAnnouncer<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("have_announcer: receive request"))?;

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -352,7 +352,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -429,7 +429,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -494,7 +494,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -587,6 +587,6 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -8,6 +8,7 @@ use veilid_core::{TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
+    error::CancelError,
     piece_map::PieceMap,
     Node, Result,
 };
@@ -145,7 +146,7 @@ impl<P: Node> Actor for HaveResolver<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("have_resolver: receive request"))?;

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -166,7 +166,7 @@ impl<P: Node> Actor for HaveResolver<P> {
                             }
                         }
                         VeilidUpdate::Shutdown => {
-                            return Ok(());
+                            cancel.cancel();
                         }
                         _ => {}
                     }

--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::sync::broadcast;
 use tracing::warn;
 use veilid_core::{RoutingContext, VeilidUpdate};
 
-pub use error::{is_cancelled, is_unrecoverable, Error, Result};
+pub use error::{is_cancelled, is_unrecoverable, CancelError, Error, Result};
 pub use node::{Node, Veilid};
 
 #[cfg(test)]

--- a/stigmerge-peer/src/peer_announcer.rs
+++ b/stigmerge-peer/src/peer_announcer.rs
@@ -160,6 +160,9 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
                                 _ => {}
                             }
                         }
+                        VeilidUpdate::Shutdown => {
+                            cancel.cancel();
+                        }
                         _ => {}
                     }
                 }

--- a/stigmerge-peer/src/peer_announcer.rs
+++ b/stigmerge-peer/src/peer_announcer.rs
@@ -8,7 +8,7 @@ use veilid_core::{TypedRecordKey, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::Unrecoverable,
+    error::{CancelError, Unrecoverable},
     proto::{self, Decoder},
     Node, Result,
 };
@@ -137,7 +137,7 @@ impl<P: Node> Actor for PeerAnnouncer<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("peer_announcer: receive request"))?;

--- a/stigmerge-peer/src/peer_announcer.rs
+++ b/stigmerge-peer/src/peer_announcer.rs
@@ -334,7 +334,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -409,7 +409,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -457,6 +457,6 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/peer_resolver.rs
+++ b/stigmerge-peer/src/peer_resolver.rs
@@ -158,7 +158,7 @@ impl<P: Node> Actor for PeerResolver<P> {
                             }
                         }
                         VeilidUpdate::Shutdown => {
-                            return Ok(());
+                            cancel.cancel();
                         }
                         _ => {}
                     }

--- a/stigmerge-peer/src/peer_resolver.rs
+++ b/stigmerge-peer/src/peer_resolver.rs
@@ -353,7 +353,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -435,7 +435,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -504,7 +504,7 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -592,6 +592,6 @@ mod tests {
 
         // Clean up
         cancel.cancel();
-        operator.join().await.expect("task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/peer_resolver.rs
+++ b/stigmerge-peer/src/peer_resolver.rs
@@ -8,7 +8,7 @@ use veilid_core::{TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::Unrecoverable,
+    error::{CancelError, Unrecoverable},
     proto::{self, Decoder, PeerInfo},
     Node, Result,
 };
@@ -120,7 +120,7 @@ impl<P: Node> Actor for PeerResolver<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("peer_resolver: receive request"))?;

--- a/stigmerge-peer/src/piece_verifier.rs
+++ b/stigmerge-peer/src/piece_verifier.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::{Result, Unrecoverable},
+    error::{CancelError, Result, Unrecoverable},
     types::PieceState,
 };
 
@@ -149,7 +149,7 @@ impl Actor for PieceVerifier {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(());
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("piece_verifier: receive request"))?;

--- a/stigmerge-peer/src/piece_verifier.rs
+++ b/stigmerge-peer/src/piece_verifier.rs
@@ -282,7 +282,7 @@ mod tests {
 
         // shut down verifier
         cancel.cancel();
-        operator.join().await.expect("verifier task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -394,7 +394,7 @@ mod tests {
 
         // shut down verifier
         cancel.cancel();
-        operator.join().await.expect("verifier task");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -458,6 +458,6 @@ mod tests {
 
         // shut down verifier
         cancel.cancel();
-        operator.join().await.expect("verifier task");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -123,10 +123,10 @@ impl<P: Node> Actor for Seeder<P> {
                     let update = res.with_context(|| format!("seeder: receive veilid update"))?;
                     match update {
                         VeilidUpdate::AppCall(veilid_app_call) => {
-                            trace!("app_call: {:?}", veilid_app_call);
                             let req = proto::Request::decode(veilid_app_call.message())?;
                             match req {
                                 proto::Request::BlockRequest(block_req) => {
+                                    trace!("app_call: {:?}", block_req);
                                     if self.piece_map.get(block_req.piece) {
                                         let rd = self.read_block_into(&block_req, &mut buf).await?;
                                         self.node.reply_block_contents(veilid_app_call.id(), Some(&buf[..rd])).await?;
@@ -136,6 +136,9 @@ impl<P: Node> Actor for Seeder<P> {
                                 }
                                 _ => {}  // Ignore other request types
                             }
+                        }
+                        VeilidUpdate::Shutdown => {
+                            cancel.cancel();
                         }
                         _ => {}
                     }

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -14,7 +14,7 @@ use veilid_core::VeilidUpdate;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::Unrecoverable,
+    error::{CancelError, Unrecoverable},
     piece_map::PieceMap,
     proto::{self, BlockRequest, Decoder},
     types::{PieceState, ShareInfo},
@@ -109,7 +109,7 @@ impl<P: Node> Actor for Seeder<P> {
             select! {
                 biased;
                 _ = cancel.cancelled() => {
-                    return Ok(());
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("seeder: receive request"))?;

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -308,7 +308,7 @@ mod tests {
 
         // Cancel the seeder
         cancel.cancel();
-        operator.join().await.expect("seeder task");
+        operator.join().await.expect_err("cancelled");
 
         // Verify reply_block_contents was called
         assert!(
@@ -411,7 +411,7 @@ mod tests {
         cancel.cancel();
 
         // Verify seeder exits cleanly
-        operator.join().await.expect("seeder task");
+        operator.join().await.expect_err("cancelled");
 
         // Verify reply_block_contents was called
         assert!(

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -146,6 +146,9 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
                                             self.reannounce().await.with_context(|| format!("share_announcer: route changed"))?;
                                         }
                                     },
+                                    VeilidUpdate::Shutdown => {
+                                        cancel.cancel();
+                                    }
                                     _ => {}
                                 }
                             }

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -296,7 +296,7 @@ mod tests {
         cancel.cancel();
 
         // Service run terminates
-        operator.join().await.expect("svc task");
+        operator.join().await.expect_err("cancelled");
     }
 
     // This test directly tests the reannounce method without using the Actor trait

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -9,7 +9,7 @@ use veilid_core::{Target, TypedRecordKey, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::Unrecoverable,
+    error::{CancelError, Unrecoverable},
     proto::Header,
     Node, Result,
 };
@@ -130,7 +130,7 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
                 Some(ShareAnnounce { target, .. }) => {
                     select! {
                         _ = cancel.cancelled() => {
-                            return Ok(());
+                            return Err(CancelError.into());
                         }
                         res = request_rx.recv_async() => {
                             let req = res.with_context(|| format!("share_announcer: receive request"))?;

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -456,7 +456,7 @@ mod tests {
         cancel.cancel();
 
         // Service run terminates
-        operator.join().await.expect("join");
+        operator.join().await.expect_err("cancelled");
     }
 
     #[tokio::test]
@@ -532,6 +532,6 @@ mod tests {
         cancel.cancel();
 
         // Service run terminates
-        operator.join().await.expect("join");
+        operator.join().await.expect_err("cancelled");
     }
 }

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -250,7 +250,7 @@ impl<P: Node> Actor for ShareResolver<P> {
                             }
                         }
                         VeilidUpdate::Shutdown => {
-                            return Ok(());
+                            cancel.cancel();
                         }
                         _ => {}
                     }

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -10,7 +10,7 @@ use veilid_core::{Target, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
     content_addressable::ContentAddressable,
-    error::Unrecoverable,
+    error::{CancelError, Unrecoverable},
     proto::{Digest, Header},
     Node, Result,
 };
@@ -226,7 +226,7 @@ impl<P: Node> Actor for ShareResolver<P> {
         loop {
             select! {
                 _ = cancel.cancelled() => {
-                    return Ok(())
+                    return Err(CancelError.into());
                 }
                 res = request_rx.recv_async() => {
                     let req = res.with_context(|| format!("share_resolver: receive request"))?;

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -18,6 +18,7 @@ use stigmerge_peer::{
     share_announcer::{self, ShareAnnouncer},
     share_resolver::{self, ShareResolver},
     types::ShareInfo,
+    CancelError,
 };
 use tokio::{
     select, spawn,
@@ -114,7 +115,7 @@ impl App {
             loop {
                 select! {
                     _ = conn_cancel.cancelled() => {
-                        return Ok::<(), Error>(());
+                        return Err(CancelError.into());
                     }
                     res = conn_state_rx.changed() => {
                         res?;
@@ -365,7 +366,7 @@ impl App {
             loop {
                 select! {
                     _ = progress_cancel.cancelled() => {
-                        return Ok(())
+                        return Err(CancelError.into());
                     }
                     res = subscribe_fetcher_status.changed() => {
                         res?;
@@ -423,7 +424,7 @@ impl App {
             loop {
                 select! {
                     _ = indexer_cancel.cancelled() => {
-                        return Ok(())
+                        return Err(CancelError.into());
                     }
                     res = subscribe_index_progress.changed() => {
                         res?;
@@ -445,7 +446,7 @@ impl App {
             loop {
                 select! {
                     _ = verifier_cancel.cancelled() => {
-                        return Ok(());
+                        return Err(CancelError.into());
                     }
                     res = subscribe_digest_progress.changed() => {
                         res?;

--- a/stigmerge/src/lib.rs
+++ b/stigmerge/src/lib.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "256"]
 
 use indicatif::MultiProgress;
-use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 pub mod app;
@@ -19,11 +18,7 @@ pub fn initialize_stdout_logging() {
                 .with_ansi(false)
                 .with_writer(std::io::stdout),
         )
-        .with(
-            EnvFilter::builder()
-                .with_default_directive("stigmerge=debug".parse().unwrap())
-                .from_env_lossy(),
-        )
+        .with(env_filter())
         .init();
 }
 
@@ -37,12 +32,16 @@ pub fn initialize_ui_logging(multi_progress: MultiProgress) {
                 .with_target(true)
                 .with_writer(move || writer.clone()),
         )
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .parse_lossy("stigmerge=debug,stigmerge_peer=debug"),
-        )
+        .with(env_filter())
         .init();
+}
+
+fn env_filter() -> EnvFilter {
+    if std::env::var("RUST_LOG").is_ok() {
+        EnvFilter::builder().from_env_lossy()
+    } else {
+        "warn,stigmerge=debug,stigmerge_peer=debug".parse().unwrap()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Return CancelError everywhere we're cancelled.

Use Done state in fetcher only when we're actually done.