### PR TITLE
fix: piece verifier tracking

### DIFF
--- a/stigmerge-peer/examples/fetcher_resolver.rs
+++ b/stigmerge-peer/examples/fetcher_resolver.rs
@@ -107,7 +107,7 @@ async fn main() -> std::result::Result<(), Error> {
 
     let piece_verifier = Operator::new(
         cancel.clone(),
-        PieceVerifier::new(want_index.clone()),
+        PieceVerifier::new(want_index.clone()).await,
         UntilCancelled,
     );
 

--- a/stigmerge-peer/examples/seeder_announcer.rs
+++ b/stigmerge-peer/examples/seeder_announcer.rs
@@ -83,7 +83,7 @@ async fn main() -> std::result::Result<(), Error> {
     let shared_index = Arc::new(RwLock::new(index.clone()));
 
     // Set up the verifier
-    let verifier = piece_verifier::PieceVerifier::new(shared_index.clone());
+    let verifier = piece_verifier::PieceVerifier::new(shared_index.clone()).await;
     let verified_rx = verifier.subscribe_verified();
     let mut verifier_op = Operator::new(cancel.clone(), verifier, OneShot);
 

--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -196,7 +196,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
         args.fetchers,
     );
 
-    let piece_verifier = PieceVerifier::new(Arc::new(RwLock::new(index.clone())));
+    let piece_verifier = PieceVerifier::new(Arc::new(RwLock::new(index.clone()))).await;
     let verified_rx = piece_verifier.subscribe_verified();
     let piece_verifier_op = Operator::new(cancel.clone(), piece_verifier, UntilCancelled);
 

--- a/stigmerge-peer/src/fetcher.rs
+++ b/stigmerge-peer/src/fetcher.rs
@@ -312,7 +312,7 @@ impl<N: Node> Fetcher<N> {
                 }
                 res = self.verify_resp_rx.recv_async() => {
                     match res.context(Unrecoverable::new("receive piece verification"))? {
-                        piece_verifier::Response::ValidPiece { file_index:_, piece_index, index_complete } => {
+                        piece_verifier::Response::ValidPiece { file_index: _, piece_index, index_complete } => {
                             verified_pieces += 1u64;
 
                             // Update verify progress

--- a/stigmerge-peer/src/types.rs
+++ b/stigmerge-peer/src/types.rs
@@ -86,11 +86,16 @@ impl PieceState {
         }
     }
 
-    pub fn merged(&mut self, other: PieceState) -> PieceState {
+    pub fn merged(mut self, other: PieceState) -> PieceState {
         if self.file_index != other.file_index || self.piece_index != other.piece_index {
             panic!("attempt to merge mismatched pieces");
         }
         self.blocks |= other.blocks;
-        self.clone()
+        self
+    }
+
+    pub fn cleared(mut self) -> PieceState {
+        self.blocks = 0;
+        self
     }
 }

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -252,7 +252,7 @@ impl App {
 
         info!("announced share, key: {share_key}");
 
-        let piece_verifier = PieceVerifier::new(Arc::new(RwLock::new(index.clone())));
+        let piece_verifier = PieceVerifier::new(Arc::new(RwLock::new(index.clone()))).await;
         let verified_rx = piece_verifier.subscribe_verified();
         let piece_verifier_op = Operator::new(cancel.clone(), piece_verifier, UntilCancelled);
 


### PR DESCRIPTION
Track piece states and completion explicitly, rather than by summary counts.

Counts can be skewed by invalid pieces and re-fetching.