### PR TITLE
fix: attribute blocks in invalid pieces to responsible peers

### DIFF
--- a/stigmerge-peer/src/types.rs
+++ b/stigmerge-peer/src/types.rs
@@ -14,7 +14,7 @@ pub struct ShareInfo {
     pub root: PathBuf,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FileBlockFetch {
     pub file_index: usize,
     pub piece_index: usize,


### PR DESCRIPTION
Track which peer last provided a block. If that block turns out to be part of an invalid piece, count the block as a fetch error against that peer.

Trace log peer scores.