### PR TITLE
fix: block peers which resolve a bad index

### DIFF
--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -272,7 +272,7 @@ mod tests {
                     }
                 }
             }
-            time::sleep(Duration::from_millis(i)).await;
+            time::sleep(Duration::from_millis(i * 10)).await;
         }
         assert!(confirmed_have_map, "confirm verified block");
 


### PR DESCRIPTION
If a peer's share key resolves to a bad index, block that peer from further advertisements. The peer key is replaced with the local share key in the peer DHT as a placeholder.

Drive-by fixes:
- Increase seeder async polling backoff delay.
- Request share on adding any peer, not just on startup load from db.

Fixes #325 