### PR TITLE
refactor: extract high level share api

### DIFF
--- a/stigmerge-fileindex/src/lib.rs
+++ b/stigmerge-fileindex/src/lib.rs
@@ -208,7 +208,7 @@ pub struct FileBlockRef {
 }
 
 /// Progress of an indexing process.
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Progress {
     pub length: u64,
     pub position: u64,

--- a/stigmerge/Cargo.toml
+++ b/stigmerge/Cargo.toml
@@ -16,6 +16,10 @@ path-guid = "F2AA53E2-105C-4A4F-BE29-C072AB5754A2"
 license = false
 eula = false
 
+[lib]
+name = "stigmerge"
+path = "src/lib.rs"
+
 [[bin]]
 name = "stigmerge"
 

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -1,39 +1,23 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use anyhow::{bail, Error, Result};
+use anyhow::{Error, Result};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
-use path_absolutize::Absolutize;
-use stigmerge_fileindex::Indexer;
-use tokio::{
-    fs::File,
-    io::AsyncWriteExt,
-    select, spawn,
-    sync::{watch, RwLock},
-    task::JoinSet,
-    time::sleep,
-};
-use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, trace, warn};
-use veilid_core::TypedRecordKey;
-
 use stigmerge_peer::{
-    actor::{ConnectionState, Operator, ResponseChannel, UntilCancelled, WithVeilidConnection},
-    block_fetcher::BlockFetcher,
-    content_addressable::ContentAddressable,
-    fetcher::{self, Clients as FetcherClients, Fetcher},
-    have_announcer::HaveAnnouncer,
+    actor::ConnectionState,
+    fetcher::{self},
     new_routing_context,
     node::{Node, Veilid},
-    peer_gossip::PeerGossip,
-    piece_verifier::PieceVerifier,
-    seeder::Seeder,
-    share_announcer::{self, ShareAnnouncer},
-    share_resolver::{self, ShareResolver},
-    types::ShareInfo,
     CancelError,
 };
+use tokio::{fs::File, io::AsyncWriteExt, select, spawn, sync::broadcast, task::JoinSet};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, trace, warn};
 
-use crate::{cli::Commands, initialize_stdout_logging, initialize_ui_logging, Cli};
+use crate::{
+    initialize_stdout_logging, initialize_ui_logging,
+    share::{Event, Share},
+    Cli,
+};
 
 pub struct App {
     cli: Cli,
@@ -146,235 +130,27 @@ impl App {
             }
         });
 
-        let root = match self.cli.commands {
-            Commands::Fetch {
-                ref output_path, ..
-            } => output_path.into(),
-            Commands::Seed { ref path } => path
-                .absolutize()?
-                .parent()
-                .ok_or(Error::msg("expected parent directory"))?
-                .to_path_buf(),
-            _ => bail!("unexpected subcommand"),
-        };
+        let (share_mode, share_config) = self.cli.commands.share_args()?;
+        let mut share = Share::new(node, conn_state, share_mode, share_config)?;
 
-        debug!("root: {}", root.to_string_lossy());
+        self.add_state_file_handler(&cancel, &mut tasks, share.subscribe_events())?;
+        self.add_fetch_progress(&cancel, &mut tasks, share.subscribe_events())?;
+        self.add_seed_indexer_progress(&cancel, &mut tasks, share.subscribe_events())?;
 
-        // Set up share resolver
-        let share_resolver = ShareResolver::new(node.clone());
-        let fetcher_share_target_rx = share_resolver.subscribe_target();
-        let seeder_share_target_rx = share_resolver.subscribe_target();
-        let mut share_resolver_op = Operator::new(
-            cancel.clone(),
-            share_resolver,
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
-        );
-        let share_resolver_tx = share_resolver_op.request_tx.clone();
-
-        // Resolve bootstrap share keys and want_index_digest
-        let mut want_index = None;
-        let mut n_fetchers = 1;
-        match &self.cli.commands {
-            Commands::Fetch {
-                share_keys,
-                index_digest,
-                fetchers,
-                ..
-            } => {
-                n_fetchers = *fetchers;
-                for share_key_str in share_keys.iter() {
-                    debug!("resolving share key: {share_key_str}");
-                    let share_key: TypedRecordKey = share_key_str.parse()?;
-                    let want_index_digest = match index_digest {
-                        Some(digest_string) => {
-                            let digest = hex::decode(digest_string)?;
-                            Some(
-                                digest
-                                    .try_into()
-                                    .map_err(|_| Error::msg("Invalid digest length"))?,
-                            )
-                        }
-                        None => None,
-                    };
-                    trace!("want_index_digest: {:?}", want_index_digest);
-
-                    // Resolve the index from the bootstrap peer
-                    let index = match share_resolver_op
-                        .call(share_resolver::Request::Index {
-                            response_tx: ResponseChannel::default(),
-                            key: share_key.clone(),
-                            want_index_digest,
-                            root: root.clone(),
-                        })
-                        .await?
-                    {
-                        share_resolver::Response::Index { index, .. } => index,
-                        share_resolver::Response::BadIndex { .. } => {
-                            anyhow::bail!("Bad index")
-                        }
-                        share_resolver::Response::NotAvailable { err_msg, .. } => {
-                            anyhow::bail!(err_msg)
-                        }
-                        _ => anyhow::bail!("Unexpected response"),
-                    };
-                    want_index.get_or_insert(index);
-                    trace!("got index from {share_key}");
-                }
-            }
-            Commands::Seed { path } => {
-                let indexer = Indexer::from_file(path).await?;
-                self.add_seed_indexer_progress(
-                    &cancel,
-                    &mut tasks,
-                    indexer.subscribe_index_progress(),
-                    indexer.subscribe_digest_progress(),
-                )?;
-                let index = indexer.index().await?;
-                want_index.get_or_insert(index);
-            }
-            c => bail!("unexpected subcommand: {:?}", c),
-        };
-        let mut index = want_index.ok_or(Error::msg("failed to resolve index"))?;
-        let index_digest = index.digest()?;
-        info!(index_digest = hex::encode(index_digest));
-
-        // Announce our own share of the index
-        let mut share_announcer_op = Operator::new(
-            cancel.clone(),
-            ShareAnnouncer::new(node.clone(), index.clone()),
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
-        );
-        let (share_key, share_header) = match share_announcer_op
-            .call(share_announcer::Request::Announce {
-                response_tx: ResponseChannel::default(),
-            })
-            .await?
-        {
-            share_announcer::Response::Announce { key, header, .. } => (key, header),
-            share_announcer::Response::NotAvailable => {
-                anyhow::bail!("failed to announce share")
-            }
-        };
-
-        info!("announced share, key: {share_key}");
-        self.write_state_file("index_digest", hex::encode(index_digest))
-            .await?;
-        self.write_state_file("share_key", share_key.to_string())
-            .await?;
-
-        let piece_verifier = PieceVerifier::new(Arc::new(RwLock::new(index.clone()))).await;
-        let verified_rx = piece_verifier.subscribe_verified();
-        let piece_verifier_op = Operator::new(cancel.clone(), piece_verifier, UntilCancelled);
-
-        // Announce our own have-map as we fetch, at our announced share's have-map key
-        let have_announcer = Operator::new(
-            cancel.clone(),
-            // TODO: should use the share key publicly; hide this from the actor / op interface
-            HaveAnnouncer::new(node.clone(), share_header.have_map().unwrap().key().clone()),
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
-        );
-
-        let share = ShareInfo {
-            key: share_key,
-            want_index: index.clone(),
-            want_index_digest: index_digest,
-            root,
-            header: share_header.clone(),
-        };
-
-        // Set up fetcher dependencies
-        let block_fetcher = Operator::new_clone_pool(
-            cancel.clone(),
-            BlockFetcher::new(
-                node.clone(),
-                Arc::new(RwLock::new(index.clone())),
-                index.root().to_path_buf(),
-            ),
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
-            n_fetchers,
-        );
-
-        let fetcher_clients = FetcherClients {
-            block_fetcher,
-            piece_verifier: piece_verifier_op,
-            have_announcer,
-            share_resolver: share_resolver_op,
-            share_target_rx: fetcher_share_target_rx,
-        };
-
-        // Create and run fetcher
-        info!("Starting fetch...");
-
-        let fetcher = Fetcher::new(node.clone(), share.clone(), fetcher_clients);
-        self.add_fetch_progress(&cancel, &mut tasks, fetcher.subscribe_fetcher_status())?;
-        let fetcher_task = spawn(fetcher.run(cancel.clone(), conn_state.clone()));
-
-        let gossip_op = Operator::new(
-            cancel.clone(),
-            PeerGossip::new(
-                node.clone(),
-                share.clone(),
-                share_resolver_tx,
-                seeder_share_target_rx,
-            ),
-            WithVeilidConnection::new(node.clone(), conn_state.clone()),
-        );
-        tasks.spawn(gossip_op.join());
-
-        // Set up seeder
-        let seeder = Seeder::new(node.clone(), share.clone(), verified_rx);
-        let seeder_op = Operator::new(
-            cancel.clone(),
-            seeder,
-            WithVeilidConnection::new(node.clone(), conn_state),
-        );
-        tasks.spawn(seeder_op.join());
-
-        info!("Seeding until ctrl-c...");
-        let seed_progress = self.multi_progress.add(ProgressBar::new_spinner());
-        seed_progress.set_style(ProgressStyle::with_template("{prefix} {msg}")?);
-        seed_progress.set_prefix("🌱");
-        seed_progress.set_message(format!(
-            "Seeding {}{} to {}",
-            index
-                .files()
-                .first()
-                .map(|f| f.path().to_string_lossy())
-                .unwrap(),
-            if index.files().len() > 1 { "..." } else { "" },
-            share_key.to_string()
-        ));
-
-        // Keep seeding until ctrl-c or fetcher exits
-        let res = select! {
-            join_res = fetcher_task => {
-                cancel.cancel();
-                match join_res {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(e)) => {
-                        error!("fetcher: {}", e);
-                        Err(e)
-                    }
-                    Err(e) => {
-                        error!("join fetcher: {}", e);
-                        Err(e.into())
-                    }
-                }
-            }
-        };
+        share.start(cancel.clone()).await?;
+        tasks.spawn(share.join());
         tasks
             .join_all()
             .await
             .into_iter()
-            .collect::<Result<(), _>>()?;
-        res
+            .collect::<Result<(), _>>()
     }
 
     fn add_fetch_progress(
         &self,
         cancel: &CancellationToken,
         tasks: &mut JoinSet<Result<()>>,
-        mut subscribe_fetcher_status: watch::Receiver<fetcher::Status>,
+        mut events: broadcast::Receiver<Event>,
     ) -> Result<()> {
         let fetch_progress = self.multi_progress.add(ProgressBar::new_spinner());
         fetch_progress.set_style(ProgressStyle::with_template(
@@ -389,9 +165,12 @@ impl App {
                     _ = progress_cancel.cancelled() => {
                         return Err(CancelError.into());
                     }
-                    res = subscribe_fetcher_status.changed() => {
-                        res?;
-                        match *subscribe_fetcher_status.borrow_and_update() {
+                    res = events.recv() => {
+                        let fetcher_status = match res? {
+                            Event::FetcherStatus(status) => status,
+                            _ => continue,
+                        };
+                        match fetcher_status {
                             fetcher::Status::IndexProgress { position, length } => {
                                 fetch_progress.set_message("Indexing");
                                 fetch_progress.set_position(position);
@@ -413,6 +192,7 @@ impl App {
                             fetcher::Status::Done => {
                                 fetch_progress.finish_with_message("Fetch complete");
                                 verify_progress.finish_and_clear();
+                                return Ok(());
                             }
                             _ => {}
                         }
@@ -427,8 +207,7 @@ impl App {
         &self,
         cancel: &CancellationToken,
         tasks: &mut JoinSet<Result<()>>,
-        mut subscribe_index_progress: watch::Receiver<stigmerge_fileindex::Progress>,
-        mut subscribe_digest_progress: watch::Receiver<stigmerge_fileindex::Progress>,
+        mut events: broadcast::Receiver<Event>,
     ) -> Result<()> {
         let indexer_progress = self.multi_progress.add(ProgressBar::new_spinner());
         indexer_progress.set_style(ProgressStyle::with_template(
@@ -438,55 +217,92 @@ impl App {
         verifier_progress.set_style(ProgressStyle::with_template(
             "{wide_bar} {binary_bytes}/{binary_total_bytes}",
         )?);
-        let indexer_cancel = cancel.clone();
+        let progress_cancel = cancel.clone();
         tasks.spawn(async move {
             loop {
                 select! {
-                    _ = indexer_cancel.cancelled() => {
+                    _ = progress_cancel.cancelled() => {
                         return Err(CancelError.into());
                     }
-                    res = subscribe_index_progress.changed() => {
-                        res?;
-                        let progress = subscribe_index_progress.borrow_and_update();
-                        if progress.length == progress.position {
+                    res = events.recv() => {
+                        let (index_progress, verify_progress) = match res? {
+                            Event::SeederLoading{ index_progress, verify_progress } => {
+                                (index_progress, verify_progress)
+                            }
+                            _ => continue,
+                        };
+                        if index_progress.length == index_progress.position {
                             indexer_progress.finish_and_clear();
-                            return Ok(());
+                        } else {
+                            indexer_progress.set_message("Indexing");
+                            indexer_progress.set_length(index_progress.length);
+                            indexer_progress.set_position(index_progress.position);
                         }
-                        indexer_progress.set_message("Indexing");
-                        indexer_progress.set_length(progress.length);
-                        indexer_progress.set_position(progress.position);
-                    }
-                }
-                sleep(Duration::from_millis(250)).await;
-            }
-        });
-        let verifier_cancel = cancel.clone();
-        tasks.spawn(async move {
-            loop {
-                select! {
-                    _ = verifier_cancel.cancelled() => {
-                        return Err(CancelError.into());
-                    }
-                    res = subscribe_digest_progress.changed() => {
-                        res?;
-                        let progress = subscribe_digest_progress.borrow_and_update();
-                        if progress.length == progress.position {
+                        if verify_progress.length == verify_progress.position {
                             verifier_progress.finish_and_clear();
-                            return Ok(());
+                            return Ok(())
                         }
                         verifier_progress.set_message("Verifying");
-                        verifier_progress.set_length(progress.length);
-                        verifier_progress.set_position(progress.position);
+                        verifier_progress.set_length(verify_progress.length);
+                        verifier_progress.set_position(verify_progress.position);
                     }
                 }
-                sleep(Duration::from_millis(250)).await;
             }
         });
         Ok(())
     }
 
-    async fn write_state_file(&self, key: &str, value: String) -> Result<()> {
+    fn add_state_file_handler(
+        &self,
+        cancel: &CancellationToken,
+        tasks: &mut JoinSet<std::result::Result<(), Error>>,
+        mut events: broadcast::Receiver<Event>,
+    ) -> Result<()> {
+        let handler_cancel = cancel.clone();
         let state_dir = self.cli.state_dir()?;
+
+        let seed_progress = self.multi_progress.add(ProgressBar::new_spinner());
+
+        tasks.spawn(async move {
+            loop {
+                select! {
+                    _ = handler_cancel.cancelled() => {
+                        return Err(CancelError.into());
+                    }
+                    res = events.recv() => {
+                        let share_info = match res? {
+                            Event::ShareInfo(share_info) => share_info,
+                            _ => continue,
+                        };
+
+                        // Write state files to state_dir, especially useful for
+                        // providing share info to other processes.
+                        Self::write_state_file(&state_dir, "index_digest",
+                            hex::encode(&share_info.want_index_digest)).await?;
+                        Self::write_state_file(&state_dir, "share_key",
+                            share_info.key.to_string()).await?;
+
+                        // Display the share info.
+                        seed_progress.set_style(ProgressStyle::with_template("{prefix} {msg}")?);
+                        seed_progress.set_prefix("🌱");
+                        seed_progress.set_message(format!(
+                            "Seeding {}{} to {}",
+                            share_info.want_index
+                                .files()
+                                .first()
+                                .map(|f| f.path().to_string_lossy())
+                                .unwrap(),
+                            if share_info.want_index.files().len() > 1 { "..." } else { "" },
+                            share_info.key.to_string()
+                        ));
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn write_state_file(state_dir: &str, key: &str, value: String) -> Result<()> {
         let state_file = PathBuf::from(state_dir).join(key);
         File::create(state_file)
             .await?

--- a/stigmerge/src/lib.rs
+++ b/stigmerge/src/lib.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 pub mod app;
 pub mod cli;
+pub mod share;
 
 pub use app::App;
 pub use cli::Cli;

--- a/stigmerge/src/share.rs
+++ b/stigmerge/src/share.rs
@@ -1,0 +1,361 @@
+use std::{ops::Deref, path::PathBuf, sync::Arc};
+
+use anyhow::{Error, Result};
+use path_absolutize::Absolutize;
+use stigmerge_fileindex::{Indexer, Progress};
+use stigmerge_peer::{
+    actor::{
+        ConnectionStateHandle, Operator, ResponseChannel, UntilCancelled, WithVeilidConnection,
+    },
+    block_fetcher,
+    content_addressable::ContentAddressable,
+    fetcher, have_announcer, peer_gossip, piece_verifier,
+    proto::Digest,
+    seeder, share_announcer, share_resolver,
+    types::ShareInfo,
+    CancelError, Node,
+};
+use tokio::{
+    select,
+    sync::{broadcast, watch, RwLock},
+    task::JoinSet,
+};
+use tokio_util::sync::CancellationToken;
+use veilid_core::TypedRecordKey;
+
+#[derive(Debug)]
+pub enum Mode {
+    Seed {
+        /// Local file to seed.
+        path: PathBuf,
+    },
+    Fetch {
+        /// Local directory where the fetched file(s) will be placed.
+        root: PathBuf,
+
+        /// Content digest of the share index (not the payload itself).
+        ///
+        /// The index digest is used to authenticate other peers advertising
+        /// that they offer the same payload. If their share DHT has an index
+        /// that doesn't match, they're not.
+        want_index_digest: Option<Digest>,
+
+        /// Share key(s) used to bootstrap into the swarm of peers sharing this
+        /// content. At least one is required.
+        share_keys: Vec<TypedRecordKey>,
+    },
+}
+
+pub struct Config {
+    pub n_fetchers: u8,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config { n_fetchers: 0 }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Event {
+    /// Share info has been published to the Veilid DHT.
+    ShareInfo(ShareInfo),
+
+    /// Fetch status has changed.
+    FetcherStatus(fetcher::Status),
+
+    /// Seeder is indexing and verify the local copy of the share. For a large
+    /// local share, this can take a little while, so progress is reported.
+    SeederLoading {
+        index_progress: stigmerge_fileindex::Progress,
+        verify_progress: stigmerge_fileindex::Progress,
+    },
+
+    /// Seeder is available to service block requests. The share may still be
+    /// incomplete. FetcherStatus(fetcher::Status::Done) indicates the share is
+    /// complete.
+    SeederAvailable,
+}
+
+pub struct Share<N: Node> {
+    node: N,
+    conn_state: ConnectionStateHandle,
+    mode: Mode,
+    config: Config,
+
+    events_tx: broadcast::Sender<Event>,
+    events_rx: broadcast::Receiver<Event>,
+
+    tasks: JoinSet<Result<()>>,
+}
+
+impl<N: Node + Send + Sync + 'static> Share<N> {
+    pub fn new(
+        node: N,
+        conn_state: ConnectionStateHandle,
+        mode: Mode,
+        config: Config,
+    ) -> Result<Self> {
+        let (events_tx, events_rx) = broadcast::channel(1024);
+        let share = Self {
+            node,
+            conn_state,
+            mode,
+            config,
+            events_tx,
+            events_rx,
+            tasks: JoinSet::new(),
+        };
+        Ok(share)
+    }
+
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.events_rx.resubscribe()
+    }
+
+    pub async fn start(&mut self, cancel: CancellationToken) -> Result<()> {
+        let root = match self.mode {
+            Mode::Seed { ref path } => path
+                .absolutize()?
+                .parent()
+                .ok_or(Error::msg("cannot determine parent directory"))?
+                .to_path_buf(),
+            Mode::Fetch { ref root, .. } => root.to_owned(),
+        };
+
+        // Set up share resolver
+        let share_resolver_actor = share_resolver::ShareResolver::new(self.node.clone());
+        let fetcher_share_target_rx = share_resolver_actor.subscribe_target();
+        let seeder_share_target_rx = share_resolver_actor.subscribe_target();
+        let mut share_resolver_op = Operator::new(
+            cancel.clone(),
+            share_resolver_actor,
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+        );
+        let share_resolver_tx = share_resolver_op.request_tx.clone();
+
+        // Resolve bootstrap share keys and want_index_digest
+        let mut want_index = None;
+        match &self.mode {
+            Mode::Fetch {
+                share_keys,
+                want_index_digest,
+                ..
+            } => {
+                for share_key in share_keys.iter() {
+                    let want_index_digest = match want_index_digest {
+                        Some(digest_string) => {
+                            let digest = hex::decode(digest_string)?;
+                            Some(
+                                digest
+                                    .try_into()
+                                    .map_err(|_| Error::msg("Invalid digest length"))?,
+                            )
+                        }
+                        None => None,
+                    };
+
+                    // Resolve the index from the bootstrap peer
+                    let index = match share_resolver_op
+                        .call(share_resolver::Request::Index {
+                            response_tx: ResponseChannel::default(),
+                            key: share_key.clone(),
+                            want_index_digest,
+                            root: root.clone(),
+                        })
+                        .await?
+                    {
+                        share_resolver::Response::Index { index, .. } => index,
+                        share_resolver::Response::BadIndex { .. } => {
+                            anyhow::bail!("Bad index")
+                        }
+                        share_resolver::Response::NotAvailable { err_msg, .. } => {
+                            anyhow::bail!(err_msg)
+                        }
+                        _ => anyhow::bail!("Unexpected response"),
+                    };
+                    want_index.get_or_insert(index);
+                }
+            }
+            Mode::Seed { path } => {
+                let indexer = Indexer::from_file(path).await?;
+                self.tasks.spawn(Self::send_indexer_progress(
+                    cancel.clone(),
+                    indexer.subscribe_index_progress(),
+                    indexer.subscribe_digest_progress(),
+                    self.events_tx.clone(),
+                ));
+                let index = indexer.index().await?;
+                want_index.get_or_insert(index);
+            }
+        };
+        let mut index = want_index.ok_or(Error::msg("failed to resolve index"))?;
+        let index_digest = index.digest()?;
+
+        // Announce our own share of the index
+        let mut share_announcer_op = Operator::new(
+            cancel.clone(),
+            share_announcer::ShareAnnouncer::new(self.node.clone(), index.clone()),
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+        );
+        let (share_key, share_header) = match share_announcer_op
+            .call(share_announcer::Request::Announce {
+                response_tx: ResponseChannel::default(),
+            })
+            .await?
+        {
+            share_announcer::Response::Announce { key, header, .. } => (key, header),
+            share_announcer::Response::NotAvailable => {
+                anyhow::bail!("failed to announce share")
+            }
+        };
+
+        let share = ShareInfo {
+            key: share_key,
+            want_index: index.clone(),
+            want_index_digest: index_digest,
+            root,
+            header: share_header.clone(),
+        };
+        self.events_tx.send(Event::ShareInfo(share.clone()))?;
+
+        let piece_verifier_actor =
+            piece_verifier::PieceVerifier::new(Arc::new(RwLock::new(index.clone()))).await;
+        let verified_rx = piece_verifier_actor.subscribe_verified();
+        let piece_verifier_op = Operator::new(cancel.clone(), piece_verifier_actor, UntilCancelled);
+
+        // Announce our own have-map as we fetch, at our announced share's have-map key
+        let have_announcer_op = Operator::new(
+            cancel.clone(),
+            // TODO: should use the share key publicly; hide this from the actor / op interface
+            have_announcer::HaveAnnouncer::new(
+                self.node.clone(),
+                share_header.have_map().unwrap().key().clone(),
+            ),
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+        );
+
+        // Set up fetcher dependencies
+        let block_fetcher_op = Operator::new_clone_pool(
+            cancel.clone(),
+            block_fetcher::BlockFetcher::new(
+                self.node.clone(),
+                Arc::new(RwLock::new(index.clone())),
+                index.root().to_path_buf(),
+            ),
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+            self.config.n_fetchers.into(),
+        );
+
+        let fetcher_clients = fetcher::Clients {
+            block_fetcher: block_fetcher_op,
+            piece_verifier: piece_verifier_op,
+            have_announcer: have_announcer_op,
+            share_resolver: share_resolver_op,
+            share_target_rx: fetcher_share_target_rx,
+        };
+
+        // Create and run fetcher
+        let fetcher_inst = fetcher::Fetcher::new(self.node.clone(), share.clone(), fetcher_clients);
+        self.tasks.spawn(Self::send_fetch_progress(
+            cancel.clone(),
+            fetcher_inst.subscribe_fetcher_status(),
+            self.events_tx.clone(),
+        ));
+        self.tasks
+            .spawn(fetcher_inst.run(cancel.clone(), self.conn_state.clone()));
+
+        let gossip_op = Operator::new(
+            cancel.clone(),
+            peer_gossip::PeerGossip::new(
+                self.node.clone(),
+                share.clone(),
+                share_resolver_tx,
+                seeder_share_target_rx,
+            ),
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+        );
+        self.tasks.spawn(gossip_op.join());
+
+        // Set up seeder
+        let seeder = seeder::Seeder::new(self.node.clone(), share.clone(), verified_rx);
+        let seeder_op = Operator::new(
+            cancel.clone(),
+            seeder,
+            WithVeilidConnection::new(self.node.clone(), self.conn_state.clone()),
+        );
+        self.tasks.spawn(seeder_op.join());
+
+        self.events_tx.send(Event::SeederAvailable)?;
+
+        Ok(())
+    }
+
+    pub async fn join(self) -> Result<()> {
+        self.tasks
+            .join_all()
+            .await
+            .into_iter()
+            .collect::<Result<(), _>>()
+    }
+
+    async fn send_indexer_progress(
+        cancel: CancellationToken,
+        mut subscribe_index_progress: watch::Receiver<stigmerge_fileindex::Progress>,
+        mut subscribe_digest_progress: watch::Receiver<stigmerge_fileindex::Progress>,
+        events_tx: broadcast::Sender<Event>,
+    ) -> Result<()> {
+        let mut index_progress = Progress::default();
+        let mut verify_progress = Progress::default();
+        loop {
+            select! {
+                _ = cancel.cancelled() => {
+                    return Err(CancelError.into());
+                }
+                res = subscribe_index_progress.changed() => {
+                    res?;
+                    let progress = subscribe_index_progress.borrow_and_update();
+                    progress.clone_into(&mut index_progress);
+                    events_tx.send(Event::SeederLoading{
+                        index_progress,
+                        verify_progress,
+                    })?;
+                }
+                res = subscribe_digest_progress.changed() => {
+                    res?;
+                    let progress = subscribe_digest_progress.borrow_and_update();
+                    progress.clone_into(&mut verify_progress);
+                    events_tx.send(Event::SeederLoading{
+                        index_progress,
+                        verify_progress,
+                    })?;
+                    if progress.length == progress.position {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    async fn send_fetch_progress(
+        cancel: CancellationToken,
+        mut subscribe_fetcher_status: watch::Receiver<fetcher::Status>,
+        events_tx: broadcast::Sender<Event>,
+    ) -> Result<()> {
+        loop {
+            select! {
+                _ = cancel.cancelled() => {
+                    return Err(CancelError.into());
+                }
+                res = subscribe_fetcher_status.changed() => {
+                    res?;
+                    let progress = subscribe_fetcher_status.borrow_and_update();
+                    events_tx.send(Event::FetcherStatus(progress.clone()))?;
+                    if let &fetcher::Status::Done = progress.deref() {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Encapsulate the peer setup necessary to operate a single payload share.

This basically provides a high-level API to applications that want to manage one or more shares concurrently in a user agent, whether a simple single-share CLI, a TUI that manages multiple shares, or a multi-platform GUI. The latter two might be something like a Transmission-style app.

This refactor replatforms the existing CLI to use the new high-level API.

Satisfies #326.

- [x] TODO: surface events in stigmerge::Share::events_tx
- [x] TODO: replatform stigmerge::App to use the new events
- [x] TODO: update stigmerge crate to provide a library in addition to the binary