### PR TITLE
fix: docs.rs build issues on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://github.com/cmars/stigmerge"
 license = "MPL-2.0"
 repository = "https://github.com/cmars/stigmerge"
 version = "0.5.7"
+rust-version = "1.88"
 
 [workspace.metadata.release]
 shared-version = true


### PR DESCRIPTION
Nightly currently fails to build, see log:

https://docs.rs/crate/stigmerge_peer/0.5.7/builds/2334574

Pinning the rustc version to the current stable at time of writing may fix this.