### PR TITLE
fix: docs.rs build for crates that depend on veilid-core

### DIFF
--- a/stigmerge-peer/Cargo.toml
+++ b/stigmerge-peer/Cargo.toml
@@ -50,3 +50,6 @@ sha2 = "0.10"
 tempfile = "3.13"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+
+[package.metadata.docs.rs]
+rustc-args = [ "--cfg" , "doc"]

--- a/stigmerge/Cargo.toml
+++ b/stigmerge/Cargo.toml
@@ -46,3 +46,6 @@ sha2 = "0.10.8"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.21", features = ["invocation"] }
+
+[package.metadata.docs.rs]
+rustc-args = [ "--cfg" , "doc"]


### PR DESCRIPTION
docs.rs seems to be failing to build stigmerge and stigmerge_peer due to a failing check build, where veilid-core is being compiled without doc config settings.

Researching why this might be the case I found
https://github.com/rust-lang/cargo/issues/8811 which suggests a workaround.

Not 100% it'll work but should be safe for everything else.