### PR TITLE
fix: join share announcer with other share operators

### DIFF
--- a/stigmerge/src/share.rs
+++ b/stigmerge/src/share.rs
@@ -209,6 +209,7 @@ impl<N: Node + Send + Sync + 'static> Share<N> {
                 anyhow::bail!("failed to announce share")
             }
         };
+        self.tasks.spawn(share_announcer_op.join());
 
         let share = ShareInfo {
             key: share_key,


### PR DESCRIPTION
The share announcer wasn't being joined with the stigmerge::share::Share join set.  It was dropped after starting the share. This allows the share to announce once, but doesn't reannounce on connection changes and route changes.

This may fix the issue identified in #347 without the need for a regular ping.