### PR TITLE
feat: expose veilid config in crate api

### DIFF
--- a/stigmerge-peer/src/veilid_config.rs
+++ b/stigmerge-peer/src/veilid_config.rs
@@ -1,13 +1,4 @@
-use std::env;
-
 use veilid_core::VeilidConfig;
-
-pub fn node_addr() -> Option<String> {
-    match env::var("NODE_ADDR") {
-        Ok(val) => Some(val),
-        Err(_) => None,
-    }
-}
 
 pub fn get_config(state_dir: String, ns: Option<String>) -> VeilidConfig {
     return VeilidConfig {


### PR DESCRIPTION
Add a routing_context constructor that accepts a VeilidConfig, building on the config-struct based approach.

Removed the NODE_ADDR env var; for a seedbox that wants to expose listeners, we'll make that decision up the stack (in the stigmerge CLI, UI, etc).

This also delegates the decision whether to UPnP or not, which can be controversial. I don't allow UPnP on my home network, but surprise UPnP might be unpleasant for some.