### PR TITLE
fix: remove reset interval from disconnected actor state

### DIFF
--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -5,7 +5,7 @@ use tokio::{
     select, spawn,
     sync::{broadcast, oneshot, watch, Mutex, MutexGuard},
     task::{self, JoinSet},
-    time::{interval, sleep},
+    time::sleep,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
@@ -338,7 +338,6 @@ impl<N: Node> WithVeilidConnection<N> {
         cancel: CancellationToken,
         state: MutexGuard<'a, ConnectionState>,
     ) -> Result<()> {
-        let mut reset_interval = interval(Duration::from_secs(120));
         loop {
             select! {
                 _ = cancel.cancelled() => {
@@ -361,10 +360,6 @@ impl<N: Node> WithVeilidConnection<N> {
                         }
                         _ => {}
                     }
-                }
-                _ = reset_interval.tick() => {
-                    warn!("resetting connection");
-                    self.node.reset().await?;
                 }
             }
         }


### PR DESCRIPTION
When a WithVeilidConnection actor is disconnected, it was resetting on an
interval of 120s.

This might not be long enough for veilid to connect, and might prevent the
connection from being established.

Thanks @bgrift (Codeberg) for spotting this!

### Drive-by

chore: increase e2e integration test script timeout

Waiting 5m per seed and fetch to establish.

Spinning up a new veilid node from scratch in CI seems to have some
variability. Some flakiness here is probably unavoidable.