### PR TITLE
feat: use low latency, unordered routes, reannounce on interval

### DIFF
--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 use tracing::warn;
-use veilid_core::{RoutingContext, VeilidConfig, VeilidUpdate};
+use veilid_core::{RoutingContext, Sequencing, VeilidConfig, VeilidUpdate};
 
 pub use error::{is_cancelled, is_unrecoverable, CancelError, Error, Result};
 pub use node::{Node, Veilid};
@@ -65,5 +65,6 @@ pub async fn new_routing_context_from_config(
     api.attach().await?;
 
     let routing_context = api.routing_context()?;
+    let routing_context = routing_context.with_sequencing(Sequencing::NoPreference);
     Ok((routing_context, update_rx))
 }

--- a/stigmerge-peer/src/node/veilid.rs
+++ b/stigmerge-peer/src/node/veilid.rs
@@ -3,8 +3,7 @@ use std::{cmp::min, path::Path, sync::Arc};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{trace, warn};
 use veilid_core::{
-    DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Target, ValueData,
-    ValueSubkeyRangeSet, VeilidAPIError, VeilidUpdate,
+    DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Sequencing, Stability, Target, ValueData, ValueSubkeyRangeSet, VeilidAPIError, VeilidUpdate, VALID_CRYPTO_KINDS
 };
 
 use stigmerge_fileindex::{FileSpec, Index, PayloadPiece, PayloadSpec};
@@ -284,7 +283,11 @@ impl Node for Veilid {
         let rc = self.routing_context.read().await;
         // Serialize index to index_bytes
         let index_bytes = index.encode()?;
-        let (announce_route, route_data) = rc.api().new_private_route().await?;
+        let (announce_route, route_data) = rc.api().new_custom_private_route(
+            &VALID_CRYPTO_KINDS,
+            Stability::LowLatency,
+            Sequencing::NoPreference,
+        ).await?;
         let mut header = Header::from_index(index, index_bytes.as_slice(), route_data.as_slice());
 
         let (have_map_key, have_map_subkeys) =
@@ -320,7 +323,11 @@ impl Node for Veilid {
         trace!(key = key.to_string());
         let rc = self.routing_context.read().await;
         self.release_prior_route(&rc, prior_route).await;
-        let (announce_route, route_data) = rc.api().new_private_route().await?;
+        let (announce_route, route_data) = rc.api().new_custom_private_route(
+            &VALID_CRYPTO_KINDS,
+            Stability::LowLatency,
+            Sequencing::NoPreference,
+        ).await?;
         let header = header.with_route_data(route_data);
         self.write_header(&rc, &key, &header).await?;
         Ok((Target::PrivateRoute(announce_route), header))


### PR DESCRIPTION
In troubleshooting mobile connectivity issues, realized that ordering is not necessary for stigmerge's use case.

Private routes published by announcing the index or reannouncing route changes to DHT now use no preference on sequencing, and low latency rather than reliable.

Because seeder routes seem to go "dead" after some time, share_announcer now reannounces on a 600s interval, which is reset by event-driven reannounces, such as route or connectivity changes. Added a trace log to help diagnose a problem with dead route matching, but the cause might be lower down the stack.