### PR TITLE
fix: use explicit owner keypair when writing dht values

### DIFF
--- a/stigmerge-peer/src/node/mod.rs
+++ b/stigmerge-peer/src/node/mod.rs
@@ -3,7 +3,9 @@ use std::{future::Future, path::Path};
 
 use backoff::ExponentialBackoff;
 use tokio::sync::broadcast;
-use veilid_core::{OperationId, Target, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
+use veilid_core::{
+    OperationId, Target, TypedKeyPair, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate,
+};
 
 use stigmerge_fileindex::Index;
 
@@ -20,10 +22,11 @@ pub trait Node: Clone + Send {
     fn announce_index(
         &mut self,
         index: &Index,
-    ) -> impl std::future::Future<Output = Result<(TypedRecordKey, Target, Header)>> + Send;
+    ) -> impl std::future::Future<Output = Result<(TypedRecordKey, TypedKeyPair, Target, Header)>> + Send;
     fn announce_route(
         &mut self,
         key: &TypedRecordKey,
+        owner_keypair: &TypedKeyPair,
         prior_route: Option<Target>,
         header: &Header,
     ) -> impl std::future::Future<Output = Result<(Target, Header)>> + Send;


### PR DESCRIPTION
This may address an instability problem that I'd mis-attributed to a potential deadlock, but had trouble isolating until recently.

I discovered in tinkering with persistent owner keys in https://codeberg.org/cmars/veilnet that RoutingContext::set_dht_value doesn't seem to work consistently without the writer key set, when reusing DHT owner keys over multiple executions.

The problem seems to have been manifesting in share_announcer like this (with logs cranked up and more instrumentation):

```
stigmerge  | 2025-09-08T16:50:32.478232Z  INFO stigmerge_peer::share_announcer: reannouncing after 600s
stigmerge  | 2025-09-08T16:50:32.478301Z TRACE reannounce:announce_route: stigmerge_peer::node::veilid: key="VLD0:Q0TGVjxV-LjDtpsj1wojsEBx8SU9egVwSlKo0bNjQoY"
stigmerge  | 2025-09-08T16:50:32.781781Z TRACE reannounce:announce_route: stigmerge_peer::node::veilid: writing header header_length=432 key="VLD0:Q0TGVjxV-LjDtpsj1wojsEBx8SU9egVwSlKo0bNjQoY" have_map_key="VLD0:1Jjs2lur5BhQGMb_-5UMTNi0uI4Z9V4ulUNg7DPm-L8" peer_map_key="VLD0:UK16cJK2cVc0BnBWF8tcyNTrOqKvCCGMgtp7JNSl4E4"
stigmerge  | 2025-09-08T16:50:32.781875Z ERROR reannounce:announce_route: stigmerge_peer::node::veilid: error=Generic: value is not writable
```

That "value is not writable" error seems to go away when the writer keypair is set (so far). It's not consistent though; set_dht_value works fine in some instances -- as if the owner key being cached under some conditions but not others, somewhere in veilid_core. Where?

I suspect it might be here: [open_existing_record_inner](https://gitlab.com/veilid/veilid/-/blob/1e3204b08d6c12804209c5ff2af0059051bdbb1d/veilid-core/src/storage_manager/mod.rs#L1622), which attempts to fall back on the default writer for the DHT record. That writer *should* be set whether we're opening an existing record or creating a new one, because stigmerge stores and loads the writer key in the former case (see [stigmerge_peer::node::Veilid::open_or_create_dht_record](https://github.com/cmars/stigmerge/blob/233115552246a5e4aea77176d42cdf2a33d6d12d/stigmerge-peer/src/node/veilid.rs#L42)

For some reason, that default writer isn't set, or isn't available after the share_announcer has been up for some time. This could be a bug in veilid-core that I need to track down.

Going to let this patch soak overnight and see if reannounces are stable. If so, I think this may have solved a really nasty subtle bug that was causing seeders to go dark after attempting to reannounce.